### PR TITLE
Fix: broken link to /jotai/basics/async page and improved text clarity

### DIFF
--- a/docs/jotai/guides/no-suspense.mdx
+++ b/docs/jotai/guides/no-suspense.mdx
@@ -5,7 +5,7 @@ nav: 3.6
 
 # No Suspense
 
-> The content of this page would be easier if you have taken a look on the [basics/async](../basics/async.md) part of the docs.
+> The content of this page will be easier to follow if you have taken a look at the [basics/async](/jotai/basics/async) part of the docs.
 
 Sometimes we need to wrap our components in suspense to use asynchronous atoms. Two kinds of atoms need Suspense.
 


### PR DESCRIPTION
* the link from the “No Suspense” doc to the “Basics/Async” doc was broken. the current link URL is https://docs.pmnd.rs/jotai/basics/async.md, so i fixed it based on the example of d705a67848fa770b760dd34fba8c86fdc7f42803
* improved the grammar of the preamble