### PR TITLE
Fix broken sandbox preview in react-three-fiber

### DIFF
--- a/src/components/mdx/Codesandbox/Codesandbox.tsx
+++ b/src/components/mdx/Codesandbox/Codesandbox.tsx
@@ -18,7 +18,7 @@ export function Codesandbox({
   tags = [],
   //
   hideTitle = false,
-  embed = false,
+  embed = true,
 }: CSB & {
   hideTitle: boolean
   embed: boolean


### PR DESCRIPTION
related to https://github.com/pmndrs/react-three-fiber/issues/3290, https://github.com/pmndrs/react-three-fiber/discussions/3154

Currently, there are issues that the 'react-three-fiber' official document does not show the preview screen of the Codesandbox properly.(e.g. https://r3f.docs.pmnd.rs/getting-started/your-first-scene#the-result)

So I solved the above error by changing the `embed` of Codesandbox to `true`.

However, I think Codesandbox is also using it in other off-source besides react-three-fiber, so I would like to ask for your opinion if there will be no problem.

```ts
export function Codesandbox({
  id,
  title = '',
  description = '',
  screenshot_url,
  tags = [],
  //
  hideTitle = false,
  embed = true, // false -> true
```

|before|after|
|---|---|
|<img width="880" alt="image" src="https://github.com/user-attachments/assets/d54b7484-6f44-470f-8230-dbb2aa41d3d3">|<img width="880" alt="image" src="https://github.com/user-attachments/assets/bafef09f-2580-4fc0-954b-d454f917d7ce">|

If you are concerned about the side effects of modifying the code of Codesandbox, I think there is also a way to modify the code of the mdx file of react-three-fiber as below.

```mdx
// https://github.com/pmndrs/react-three-fiber/blob/master/docs/getting-started/your-first-scene.mdx?plain=1#L159C1-L159C27

<Codesandbox id="12q81" embed />
```