### PR TITLE
fix: Escape special characters in SearchModal to prevent regex errors

### DIFF
--- a/src/components/Search/SearchModalContainer.tsx
+++ b/src/components/Search/SearchModalContainer.tsx
@@ -4,6 +4,7 @@ import * as React from 'react'
 import { useDocs } from '@/app/[...slug]/DocsContext'
 
 import cn from '@/lib/cn'
+import { escape } from '@/utils/text'
 import { Command } from 'cmdk'
 import { useRouter } from 'next/navigation'
 import { ComponentProps } from 'react'
@@ -27,7 +28,7 @@ export const SearchModalContainer = ({
 
       // Get length of matched text in result
       const relevanceOf = (result: SearchResult) =>
-        (result.title.toLowerCase().match(deferredQuery.toLowerCase())?.length ?? 0) /
+        (result.title.toLowerCase().match(escape(deferredQuery.toLowerCase()))?.length ?? 0) /
         result.title.length
 
       // Search

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -8,5 +8,5 @@ export const escape = (text: string) => text.replace(/[|\\{}()[\]^$+*?.]/g, '\\$
  */
 export const highlight = (text: string, target: string) =>
   target.length > 0
-    ? text.replace(new RegExp(target, 'gi'), (match: string) => `<mark>${match}</mark>`)
+    ? text.replace(new RegExp(escape(target), 'gi'), (match: string) => `<mark>${match}</mark>`)
     : text


### PR DESCRIPTION
Resolves regex errors in SearchModal caused by unescaped special characters in user input.

### [AS-IS]

https://github.com/user-attachments/assets/c717a695-dc66-472d-886c-be8119dcdbb0


### [TO-BE]


https://github.com/user-attachments/assets/490fb206-4694-4ade-80f4-06b3b2179aa3








