### PR TITLE
User-passed props should overwrite those returned by fetchCSB

### DIFF
--- a/src/components/mdx/Codesandbox/Codesandbox.tsx
+++ b/src/components/mdx/Codesandbox/Codesandbox.tsx
@@ -98,6 +98,6 @@ export async function Codesandbox1({ boxes, ...props }: { boxes: string[] } & Co
   // console.log('data', data)
 
   // Merge initial props with data
-  const merged = { ...props, ...data }
+  const merged = { ...data, ...props }
   return <Codesandbox0 {...merged} />
 }


### PR DESCRIPTION
The current ordering of props destructuring prevents applying custom screenshot_url to CSBs. This quick PR fixes that.