### PR TITLE
feat: Add `rel` attributes to next/prev links

### DIFF
--- a/src/app/[...slug]/layout.tsx
+++ b/src/app/[...slug]/layout.tsx
@@ -137,7 +137,9 @@ export default async function Layoutt({ params, children }: Props) {
                   Previous
                 </label>
                 <div className="text-xl">
-                  <Link href={previousPage.url}>{previousPage.title}</Link>
+                  <Link href={previousPage.url} rel="prev">
+                    {previousPage.title}
+                  </Link>
                 </div>
               </div>
             )}
@@ -152,7 +154,9 @@ export default async function Layoutt({ params, children }: Props) {
                   Next
                 </label>
                 <div className="text-xl">
-                  <Link href={nextPage.url}>{nextPage.title}</Link>
+                  <Link href={nextPage.url} rel="next">
+                    {nextPage.title}
+                  </Link>
                 </div>
               </div>
             )}


### PR DESCRIPTION
`<a>`'s [`rel=next`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel#next)/[`rel=prev`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel#prev) enable accessibility software to detect the relationship between pages. (Next.js passes props like this straight through from `<Link>`.)