### PR TITLE
feat: Removing the $ on the copy code sections of the getting-started page

### DIFF
--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -15,9 +15,9 @@ nav: 0
 ## INSTALL
 
 ```sh
-$ git clone https://github.com/pmndrs/docs.git
-$ cd docs
-$ npm ci
+git clone https://github.com/pmndrs/docs.git
+cd docs
+npm ci
 ```
 
 ## Configuration
@@ -91,7 +91,7 @@ We implement [m3 design system](https://m3.material.io/styles/color/system/overv
 ## dev
 
 ```sh
-$ (
+(
   trap 'kill -9 0' SIGINT
 
   export _PORT=60141
@@ -139,7 +139,7 @@ Then go to: http://localhost:3000
 ## build
 
 ```sh
-$ (
+(
   trap 'kill -9 0' SIGINT
 
   rm -rf out
@@ -193,7 +193,7 @@ $ docker build -t pmndrs-docs .
 
 ```sh
 $ cd ~/code/pmndrs/react-three-fiber
-$ (
+(
   trap 'kill -9 0' SIGINT
 
   export _PORT=60141


### PR DESCRIPTION
I get the idea of trying to indicate with a $ that the command or code snippet is something that should be inserted into the command line, but by putting the $ into the code snippet, it makes the copy command button a little useless as pressing the copy button copies the whole text, which results in an error when pasting into the terminal. I vote that we remove the $ as most devs will understand that this is something that should go in the terminal without seeing the $