### PR TITLE
fix: code copy button now copies full code block

### DIFF
--- a/src/components/mdx/Code/Code.tsx
+++ b/src/components/mdx/Code/Code.tsx
@@ -1,16 +1,15 @@
 'use client'
 
 import cn from '@/lib/cn'
-import { ComponentProps, isValidElement, ReactNode, useEffect, useState } from 'react'
+import { ComponentProps, useEffect, useRef, useState } from 'react'
 import { TbClipboard, TbClipboardCheck } from 'react-icons/tb'
 
 export const Code = ({ children, className, ...props }: ComponentProps<'pre'>) => {
   const [copied, setCopied] = useState(false)
+  const ref = useRef<HTMLPreElement>(null)
 
   const handleClick = async () => {
-    const textToCopy = extractTextFromChildren(children)
-
-    await navigator.clipboard.writeText(textToCopy)
+    await navigator.clipboard.writeText(ref.current?.textContent ?? '')
     setCopied(true)
   }
 
@@ -23,6 +22,7 @@ export const Code = ({ children, className, ...props }: ComponentProps<'pre'>) =
   return (
     <div className={cn('relative')}>
       <pre
+        ref={ref}
         {...props}
         className={cn(
           className,
@@ -41,24 +41,4 @@ export const Code = ({ children, className, ...props }: ComponentProps<'pre'>) =
       </button>
     </div>
   )
-}
-
-// Recursive function to extract text content from React nodes
-const extractTextFromChildren = (children: ReactNode): string => {
-  if (typeof children === 'string') {
-    return children
-  }
-
-  if (Array.isArray(children)) {
-    return children.map(extractTextFromChildren).join('')
-  }
-
-  if (isValidElement(children)) {
-    const props = children.props as Record<string, unknown>
-    if ('children' in props) {
-      return extractTextFromChildren(props.children as ReactNode)
-    }
-  }
-
-  return ''
 }


### PR DESCRIPTION
Closes #546

### Problem
The copy button in code blocks only copies partial content. `extractTextFromChildren` recursively walks the React element tree using `isValidElement`, but `next-mdx-remote/rsc` renders code blocks as React Server Components, where lines are streamed to the client as lazy chunks. `isValidElement` returns `false` for these, so the function silently drops everything from that point in the tree.

### Fix
Replace `extractTextFromChildren` with r`ef.current.textContent` on the `<pre>` element. By the time the copy button is clicked, the browser has already rendered the full RSC output into real DOM text nodes and `textContent` reads from there directly, regardless of how React internally represented the element tree.
This also removes the dependency on `isValidElement`, which is a legacy React API not designed for RSC.