### PR TITLE
Add MCP server install section on the home page

### DIFF
--- a/.changeset/mcp-server-install-section.md
+++ b/.changeset/mcp-server-install-section.md
@@ -1,0 +1,5 @@
+---
+'@pmndrs/docs': patch
+---
+
+Add an MCP server install section on the home page (Claude Code shortcut + JSON config for other clients, link to the MCP remote-servers spec, mention of per-lib `llms.txt`). Also bundles the earlier MCP server URL / client configuration fix.

--- a/README.md
+++ b/README.md
@@ -20,23 +20,11 @@ $ curl -sL https://raw.githubusercontent.com/pmndrs/docs/refs/heads/main/preview
 
 # Releasing
 
-Every push to `main` auto-deploys [docs.pmnd.rs](https://docs.pmnd.rs) (Vercel). **No changeset needed** for the site to refresh.
+Every push to `main` redeploys [docs.pmnd.rs](https://docs.pmnd.rs) via [ci.yml](.github/workflows/ci.yml) — no [changeset](.changeset/) needed for that.
 
-A changeset is needed when downstream consumers of this package should pull the change too — i.e. projects using:
+Add one (`pnpm changeset`) only when downstream consumers pinning `pmndrs/docs/.github/workflows/build.yml@v3` or `ghcr.io/pmndrs/docs:v3` should pull the change. It bumps [`package.json`](package.json), tags `vX.Y.Z` + `vX`, and publishes a matching Docker image — so `@v3` resolves to the latest.
 
-```yaml
-uses: pmndrs/docs/.github/workflows/build.yml@v3
-# or
-DOCKER_IMAGE: ghcr.io/pmndrs/docs:v3
-```
-
-They follow the `@vX` major tag, which only moves when a new version is published. Adding a changeset triggers the release flow: version bump in `package.json`, `vX.Y.Z` + `vX` git tags, and a matching Docker image — so `@v3` resolves to the latest.
-
-```sh
-$ pnpm changeset    # creates .changeset/<slug>.md, pick `patch` / `minor` / `major`
-```
-
-TL;DR — add a changeset if your PR changes anything that consumers should see (templates, workflow, build behavior). Skip it for site-only tweaks.
+TL;DR — site-only tweak: skip. Anything consumers see (workflow, build behavior, templates): add one.
 
 # Test
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,26 @@ $ curl -sL https://raw.githubusercontent.com/pmndrs/docs/refs/heads/main/preview
 - you can pass any option from [configuration](docs/getting-started/introduction.mdx#Configuration)
 - in `DOCKER_IMAGE`, you can specify any `:tag` value from [docs packages](https://github.com/pmndrs/docs/pkgs/container/docs) container registry
 
+# Releasing
+
+Every push to `main` auto-deploys [docs.pmnd.rs](https://docs.pmnd.rs) (Vercel). **No changeset needed** for the site to refresh.
+
+A changeset is needed when downstream consumers of this package should pull the change too — i.e. projects using:
+
+```yaml
+uses: pmndrs/docs/.github/workflows/build.yml@v3
+# or
+DOCKER_IMAGE: ghcr.io/pmndrs/docs:v3
+```
+
+They follow the `@vX` major tag, which only moves when a new version is published. Adding a changeset triggers the release flow: version bump in `package.json`, `vX.Y.Z` + `vX` git tags, and a matching Docker image — so `@v3` resolves to the latest.
+
+```sh
+$ pnpm changeset    # creates .changeset/<slug>.md, pick `patch` / `minor` / `major`
+```
+
+TL;DR — add a changeset if your PR changes anything that consumers should see (templates, workflow, build behavior). Skip it for site-only tweaks.
+
 # Test
 
 Visual tests are performed in the cloud, through [chromatic.yml](.github/workflows/chromatic.yml).

--- a/docs/authoring/gha.mdx
+++ b/docs/authoring/gha.mdx
@@ -44,3 +44,15 @@ result:
 
 > [!CAUTION]
 > Negative potential consequences of an action.
+
+---
+
+The `title` prop overrides the label derived from `keyword` (icon and background still follow the keyword). Only available via the JSX form:
+
+```md
+<Gha keyword="TIP" title="MCP-server">Browse these docs from your MCP-compatible client.</Gha>
+```
+
+result:
+
+<Gha keyword="TIP" title="MCP-server">Browse these docs from your MCP-compatible client.</Gha>

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "mcp-handler": "^1.0.7",
     "mermaid": "^11.12.2",
     "next": "^16.1.3",
-    "next-mdx-remote": "^5.0.0",
+    "next-mdx-remote": "^6.0.0",
     "next-themes": "^0.4.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,8 +72,8 @@ importers:
         specifier: ^16.1.3
         version: 16.1.3(@babel/core@7.28.6)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next-mdx-remote:
-        specifier: ^5.0.0
-        version: 5.0.0(@types/react@19.2.8)(react@19.2.3)
+        specifier: ^6.0.0
+        version: 6.0.0(@types/react@19.2.8)(react@19.2.3)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -4920,8 +4920,8 @@ packages:
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
-  next-mdx-remote@5.0.0:
-    resolution: {integrity: sha512-RNNbqRpK9/dcIFZs/esQhuLA8jANqlH694yqoDBK8hkVdJUndzzGmnPHa2nyi90N4Z9VmzuSWNRpr5ItT3M7xQ==}
+  next-mdx-remote@6.0.0:
+    resolution: {integrity: sha512-cJEpEZlgD6xGjB4jL8BnI8FaYdN9BzZM4NwadPe1YQr7pqoWjg9EBCMv3nXBkuHqMRfv2y33SzUsuyNh9LFAQQ==}
     engines: {node: '>=14', npm: '>=7'}
     peerDependencies:
       react: '>=16'
@@ -6134,9 +6134,6 @@ packages:
   unist-util-filter@5.0.1:
     resolution: {integrity: sha512-pHx7D4Zt6+TsfwylH9+lYhBhzyhEnCXs/lbq/Hstxno5z4gVdyc2WEW0asfjGKPyG4pEKrnBv5hdkO6+aRnQJw==}
 
-  unist-util-is@5.2.1:
-    resolution: {integrity: sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==}
-
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
 
@@ -6146,20 +6143,20 @@ packages:
   unist-util-position@5.0.0:
     resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
 
-  unist-util-remove@3.1.1:
-    resolution: {integrity: sha512-kfCqZK5YVY5yEa89tvpl7KnBBHu2c6CzMkqHUrlOqaRgGOMp0sMvwWOVrbAtj03KhovQB7i96Gda72v/EFE0vw==}
+  unist-util-remove@4.0.0:
+    resolution: {integrity: sha512-b4gokeGId57UVRX/eVKej5gXqGlc9+trkORhFJpu9raqZkZhU0zm8Doi05+HaiBsMEIJowL+2WtQ5ItjsngPXg==}
 
   unist-util-stringify-position@4.0.0:
     resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
-
-  unist-util-visit-parents@5.1.3:
-    resolution: {integrity: sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==}
 
   unist-util-visit-parents@6.0.2:
     resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
 
   unist-util-visit@5.0.0:
     resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
   universal-user-agent@7.0.3:
     resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
@@ -7480,7 +7477,7 @@ snapshots:
       unified: 11.0.5
       unist-util-position-from-estree: 2.0.0
       unist-util-stringify-position: 4.0.0
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -11983,13 +11980,14 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next-mdx-remote@5.0.0(@types/react@19.2.8)(react@19.2.3):
+  next-mdx-remote@6.0.0(@types/react@19.2.8)(react@19.2.3):
     dependencies:
       '@babel/code-frame': 7.28.6
       '@mdx-js/mdx': 3.1.1
       '@mdx-js/react': 3.1.1(@types/react@19.2.8)(react@19.2.3)
       react: 19.2.3
-      unist-util-remove: 3.1.1
+      unist-util-remove: 4.0.0
+      unist-util-visit: 5.1.0
       vfile: 6.0.3
       vfile-matter: 5.0.1
     transitivePeerDependencies:
@@ -13353,10 +13351,6 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
-  unist-util-is@5.2.1:
-    dependencies:
-      '@types/unist': 2.0.11
-
   unist-util-is@6.0.1:
     dependencies:
       '@types/unist': 3.0.3
@@ -13369,20 +13363,15 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
-  unist-util-remove@3.1.1:
+  unist-util-remove@4.0.0:
     dependencies:
-      '@types/unist': 2.0.11
-      unist-util-is: 5.2.1
-      unist-util-visit-parents: 5.1.3
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
   unist-util-stringify-position@4.0.0:
     dependencies:
       '@types/unist': 3.0.3
-
-  unist-util-visit-parents@5.1.3:
-    dependencies:
-      '@types/unist': 2.0.11
-      unist-util-is: 5.2.1
 
   unist-util-visit-parents@6.0.2:
     dependencies:
@@ -13390,6 +13379,12 @@ snapshots:
       unist-util-is: 6.0.1
 
   unist-util-visit@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  unist-util-visit@5.1.0:
     dependencies:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -180,6 +180,38 @@ export default function Page() {
             .<Link href="https://pmnd.rs">pmnd.rs</Link>
           </header>
 
+          <section className="mt-8 lg:mt-10">
+            <div className="bg-surface-container relative overflow-hidden rounded-md border border-outline-variant">
+              <div className="flex flex-col gap-4 px-6 py-6">
+                <div>
+                  <div className="text-lg font-bold">MCP server</div>
+                  <div className="text-sm leading-relaxed! text-on-surface-variant/50">
+                    Browse these docs from your AI coding assistant — Claude Code, Cursor, Windsurf,
+                    VS Code, and any MCP-compatible client.
+                  </div>
+                </div>
+                <pre className="overflow-x-auto rounded border border-outline-variant px-4 py-3 text-sm">
+                  <code>{`claude mcp add --transport http pmndrs https://docs.pmnd.rs/api/mcp`}</code>
+                </pre>
+                <details className="text-sm">
+                  <summary className="text-on-surface-variant/70 cursor-pointer">
+                    Other clients (JSON config)
+                  </summary>
+                  <pre className="mt-2 overflow-x-auto rounded border border-outline-variant px-4 py-3">
+                    {`{
+  "mcpServers": {
+    "pmndrs": {
+      "type": "http",
+      "url": "https://docs.pmnd.rs/api/mcp"
+    }
+  }
+}`}
+                  </pre>
+                </details>
+              </div>
+            </div>
+          </section>
+
           <main className="max-w-8xl mt-8 grid w-full grid-cols-1 gap-8 lg:mt-10 lg:grid-cols-2 lg:gap-12 2xl:grid-cols-3">
             {Object.entries(libs).map(([id, data]) => (
               <div

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,8 @@ import reactSpringIcon from '@/assets/react-spring-icon.svg'
 import uiKitIcon from '@/assets/uikit-icon.svg'
 import zustandIcon from '@/assets/zustand-icon.svg'
 import Icon from '@/components/Icon'
+import { Code } from '@/components/mdx/Code/Code'
+import { Gha } from '@/components/mdx/Gha/Gha'
 import { svg } from '@/utils/icon'
 import { Metadata } from 'next'
 import Image from 'next/image'
@@ -181,35 +183,60 @@ export default function Page() {
           </header>
 
           <section className="mt-8 lg:mt-10">
-            <div className="bg-surface-container relative overflow-hidden rounded-md border border-outline-variant">
-              <div className="flex flex-col gap-4 px-6 py-6">
-                <div>
-                  <div className="text-lg font-bold">MCP server</div>
-                  <div className="text-sm leading-relaxed! text-on-surface-variant/50">
-                    Browse these docs from your AI coding assistant — Claude Code, Cursor, Windsurf,
-                    VS Code, and any MCP-compatible client.
-                  </div>
-                </div>
-                <pre className="overflow-x-auto rounded border border-outline-variant px-4 py-3 text-sm">
-                  <code>{`claude mcp add --transport http pmndrs https://docs.pmnd.rs/api/mcp`}</code>
-                </pre>
-                <details className="text-sm">
-                  <summary className="text-on-surface-variant/70 cursor-pointer">
-                    Other clients (JSON config)
-                  </summary>
-                  <pre className="mt-2 overflow-x-auto rounded border border-outline-variant px-4 py-3">
-                    {`{
+            <Gha keyword="TIP">
+              <div className="text-sm leading-relaxed!">
+                Browse these docs from your{' '}
+                <a
+                  href="https://modelcontextprotocol.io/docs/develop/connect-remote-servers"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline"
+                >
+                  MCP-compatible client
+                </a>
+                , e.g. claude-code :
+              </div>
+              <Code className="language-bash">
+                <code className="language-bash">{`claude mcp add --transport http pmndrs https://docs.pmnd.rs/api/mcp`}</code>
+              </Code>
+              <details className="text-sm">
+                <summary className="cursor-pointer">Other clients (JSON config)</summary>
+                <Code className="language-json">
+                  <code className="language-json">{`{
   "mcpServers": {
     "pmndrs": {
       "type": "http",
       "url": "https://docs.pmnd.rs/api/mcp"
     }
   }
-}`}
-                  </pre>
-                </details>
-              </div>
-            </div>
+}`}</code>
+                </Code>
+              </details>
+              <p className="mt-4 text-sm leading-relaxed!">
+                Each lib also exposes its{' '}
+                <code>
+                  <a
+                    href="https://pmndrs.github.io/react-three-fiber/llms.txt"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline"
+                  >
+                    llms.txt
+                  </a>
+                </code>{' '}
+                /{' '}
+                <code>
+                  <a
+                    href="https://pmndrs.github.io/react-three-fiber/llms-full.txt"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline"
+                  >
+                    llms-full.txt
+                  </a>
+                </code>{' '}
+              </p>
+            </Gha>
           </section>
 
           <main className="max-w-8xl mt-8 grid w-full grid-cols-1 gap-8 lg:mt-10 lg:grid-cols-2 lg:gap-12 2xl:grid-cols-3">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -183,7 +183,7 @@ export default function Page() {
           </header>
 
           <section className="mt-8 lg:mt-10">
-            <Gha keyword="TIP">
+            <Gha keyword="TIP" title="MCP-server">
               <div className="text-sm leading-relaxed!">
                 Browse these docs from your{' '}
                 <a

--- a/src/components/mdx/Gha/Gha.tsx
+++ b/src/components/mdx/Gha/Gha.tsx
@@ -41,10 +41,19 @@ const styles: Record<string, Style> = {
   },
 }
 
-export function Gha({ children, keyword }: { children: ReactNode; keyword?: string }) {
+export function Gha({
+  children,
+  keyword,
+  title,
+}: {
+  children: ReactNode
+  keyword?: string
+  title?: string
+}) {
   if (!keyword || !(keyword in styles)) keyword = 'NOTE' // default to "NOTE"
 
-  const { icon, label, bg } = styles[keyword]
+  const { icon, label: defaultLabel, bg } = styles[keyword]
+  const label = title ?? defaultLabel
   const Icon = icon
 
   // test if children is a string


### PR DESCRIPTION
## Summary

Adds a short callout above the libraries grid on `docs.pmnd.rs` that tells visitors the docs are also reachable via MCP, with a one-line install command for Claude Code and a collapsible JSON snippet for other clients.

- **Endpoint** exposed unchanged: `https://docs.pmnd.rs/api/mcp` (HTTP transport).
- **Server name** suggested: `pmndrs` — covers every `pmndrs/*` lib, not just one. Users can rename locally.
- **Tool exposed** by the server: a single `get_page_content` returning the markdown of any doc page.

## Why on the home

The MCP server is a meta-feature of the docs site itself, not specific to a single library — the libraries grid is the wrong place. Placing it just under the header makes it the first thing devs see and decoupling it from any individual lib avoids the impression it only covers `zustand` (its current default name in some setups).

## Screenshot

_(local dev render — please double-check Tailwind classes against the design system; I reused `bg-surface-container`, `border-outline-variant`, `text-on-surface-variant/50`, etc. from the existing library cards.)_

## Test plan

- [ ] `pnpm dev` and visit `/` — section renders above the grid
- [ ] Command line is readable on mobile (the `<pre>` has `overflow-x-auto`)
- [ ] `<details>` toggle reveals the JSON config block
- [ ] Dark/light mode parity