### PR TITLE
Redirect /denoiser to its self-hosted docs site

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -91,6 +91,11 @@ const nextConfig = {
         destination: 'https://pmndrs.github.io/xr/docs/:slug*',
         permanent: true,
       },
+      {
+        source: '/denoiser/:slug*',
+        destination: 'https://pmndrs.github.io/denoiser/docs/:slug*',
+        permanent: true,
+      },
     ]
   },
 }


### PR DESCRIPTION
Adds the standard redirect for [pmndrs/denoiser](https://github.com/pmndrs/denoiser), which hosts its docs on GitHub Pages at https://pmndrs.github.io/denoiser/docs/ (built with `ghcr.io/pmndrs/docs:3`, same system as uikit/xr).

```
/denoiser/:slug*  ->  https://pmndrs.github.io/denoiser/docs/:slug*
```

Follows the existing `uikit` / `xr` entries exactly. `docs.pmnd.rs/denoiser` currently 500s, so this only adds a working path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)