### PR TITLE
Only serve libraries over MCP that actually publish a llms-full.txt

### DIFF
--- a/src/app/api/[transport]/route.test.ts
+++ b/src/app/api/[transport]/route.test.ts
@@ -147,46 +147,43 @@ describe('MCP Route Handler', () => {
   })
 
   describe('Library Filtering', () => {
-    it('should include libraries with pmndrs.github.io URLs', async () => {
-      const mockLibs = {
-        'react-three-fiber': { docs_url: 'https://r3f.docs.pmnd.rs' },
-        zustand: { docs_url: 'https://zustand.docs.pmnd.rs' },
-      }
+    it('should expose exactly the libraries flagged with llms_full', async () => {
+      const { libs } = await import('@/app/page')
 
-      const filtered = Object.entries(mockLibs).filter(([, lib]) =>
-        lib.docs_url.includes('pmndrs.github.io'),
-      )
+      const exposed = Object.entries(libs)
+        .filter(([, lib]) => 'llms_full' in lib && lib.llms_full)
+        .map(([libname]) => libname)
 
-      // Note: Our test URLs don't have pmndrs.github.io, so this would be 0
-      // In real implementation, r3f.docs.pmnd.rs redirects to pmndrs.github.io
-      expect(filtered.length).toBeGreaterThanOrEqual(0)
+      expect(exposed).toEqual(['react-three-fiber', 'drei', 'zustand', 'docs'])
     })
 
-    it('should include libraries with local paths', async () => {
-      const mockLibs = {
-        docs: { docs_url: '/docs' },
-        external: { docs_url: 'https://external.com' },
+    it('should exclude pmndrs.github.io libraries that publish no llms-full.txt', async () => {
+      const { libs } = await import('@/app/page')
+
+      // Regression: these are hosted on pmndrs.github.io but are not built with this
+      // generator, so `${docs_url}/llms-full.txt` 404s. Selecting on the host alone
+      // used to expose them with a silently empty index.
+      for (const libname of [
+        'a11y',
+        'react-postprocessing',
+        'uikit',
+        'xr',
+        'prai',
+        'viverse',
+        'leva',
+      ] as const) {
+        const lib = libs[libname]
+        expect(lib.docs_url).toContain('pmndrs.github.io')
+        expect('llms_full' in lib && lib.llms_full).toBeFalsy()
       }
-
-      const filtered = Object.entries(mockLibs).filter(([, lib]) => lib.docs_url.startsWith('/'))
-
-      expect(filtered.length).toBe(1)
-      expect(filtered[0][0]).toBe('docs')
     })
 
-    it('should filter out libraries without pmndrs.github.io or local paths', async () => {
-      const mockLibs = {
-        valid1: { docs_url: 'https://pmndrs.github.io/lib1' },
-        valid2: { docs_url: '/local-lib' },
-        invalid: { docs_url: 'https://other-site.com' },
+    it('should exclude libraries documented outside pmndrs', async () => {
+      const { libs } = await import('@/app/page')
+
+      for (const libname of ['react-spring', 'jotai', 'valtio'] as const) {
+        expect('llms_full' in libs[libname] && libs[libname].llms_full).toBeFalsy()
       }
-
-      const filtered = Object.entries(mockLibs).filter(
-        ([, lib]) => lib.docs_url.includes('pmndrs.github.io') || lib.docs_url.startsWith('/'),
-      )
-
-      expect(filtered.length).toBe(2)
-      expect(filtered.find(([name]) => name === 'invalid')).toBeUndefined()
     })
   })
 
@@ -299,6 +296,38 @@ Content with &lt;special&gt; characters &amp; symbols.
       const fullUrl = localPath.startsWith('/') ? baseUrl : localPath
 
       expect(fullUrl).toBe(baseUrl)
+    })
+
+    it('should error, not return an empty index, when llms-full.txt is missing', async () => {
+      // Regression: the index resource used to skip the response.ok check, so a 404
+      // parsed as zero <page> elements and shipped an empty index. A client reads that
+      // as "this library has no pages" and starts guessing paths.
+      server.use(
+        http.get('https://pmndrs.github.io/react-three-fiber/llms-full.txt', () => {
+          return new HttpResponse('Not Found', { status: 404 })
+        }),
+      )
+
+      const { POST } = await import('./route')
+      const response = await POST(
+        new Request('https://docs.pmnd.rs/api/mcp', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json, text/event-stream',
+          },
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'resources/read',
+            params: { uri: 'docs://react-three-fiber/index' },
+          }),
+        }),
+      )
+
+      const body = await response.text()
+      expect(body).toContain('Failed to fetch')
+      expect(body).not.toContain('"text":""')
     })
   })
 

--- a/src/app/api/[transport]/route.test.ts
+++ b/src/app/api/[transport]/route.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll, afterEach, vi, beforeEach } from 'vitest'
 import { setupServer } from 'msw/node'
 import { http, HttpResponse } from 'msw'
+import { libs } from '@/app/page'
 
 // Mock Next.js headers before importing the route
 vi.mock('next/headers', () => ({
@@ -29,9 +30,22 @@ Optimize your React Three Fiber applications.
 </page>
 `
 
+// Every URL the route can reach, derived from `libs` so the mocks cannot drift away
+// from the real docs_urls. The previous handlers pointed at r3f.docs.pmnd.rs and
+// zustand.docs.pmnd.rs, which the route never requests.
+const llmsFullHandlers = Object.values(libs)
+  .filter((lib) => 'llms_full' in lib && lib.llms_full)
+  .map((lib) => {
+    // A local docs_url is served from the current host, mocked as docs.pmnd.rs below
+    const origin = lib.docs_url.startsWith('/') ? 'https://docs.pmnd.rs' : lib.docs_url
+    return http.get(`${origin}/llms-full.txt`, () => HttpResponse.text(mockLlmsFullTxt))
+  })
+
 // Setup MSW server
 const server = setupServer(
-  // Mock llms-full.txt for external libraries
+  ...llmsFullHandlers,
+
+  // Hosts the standalone fetch-and-parse tests below call directly
   http.get('https://r3f.docs.pmnd.rs/llms-full.txt', () => {
     return HttpResponse.text(mockLlmsFullTxt)
   }),
@@ -41,7 +55,10 @@ const server = setupServer(
   }),
 )
 
-beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }))
+// 'error', not 'warn': a unit test that quietly reaches the network is not isolated,
+// and it was doing exactly that -- the one test importing ./route was dead (see the
+// @/package.json alias in vitest.config.ts), so nobody noticed it had no mock
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
 afterEach(() => server.resetHandlers())
 afterAll(() => server.close())
 
@@ -333,11 +350,12 @@ Content with &lt;special&gt; characters &amp; symbols.
 
   describe('get_page_content Tool', () => {
     it('should retrieve page content successfully', async () => {
-      const { GET } = await import('./route')
-      const mockRequest = new Request('https://docs.pmnd.rs/api/sse', {
+      const { POST } = await import('./route')
+      const mockRequest = new Request('https://docs.pmnd.rs/api/mcp', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          Accept: 'application/json, text/event-stream',
         },
         body: JSON.stringify({
           jsonrpc: '2.0',
@@ -353,8 +371,14 @@ Content with &lt;special&gt; characters &amp; symbols.
         }),
       })
 
-      const response = await GET(mockRequest)
-      expect(response).toBeDefined()
+      const response = await POST(mockRequest)
+      const body = await response.text()
+
+      // Assert on the content, not merely that something came back: this test used to
+      // check toBeDefined(), which an error response satisfies just as well -- so it
+      // passed while the module failed to import, and would pass again unmocked
+      expect(body).toContain('This hook allows you to execute code on every frame')
+      expect(body).not.toContain('MCP server error')
     })
 
     it('should return error when page not found', async () => {

--- a/src/app/api/[transport]/route.ts
+++ b/src/app/api/[transport]/route.ts
@@ -7,11 +7,11 @@ import { libs, type SUPPORTED_LIBRARY_NAMES } from '@/app/page'
 import packageJson from '@/package.json' with { type: 'json' }
 
 // Extract entries and library names as constants for efficiency
-// Only support libraries with pmndrs.github.io in their docs_url (which have <page> tags in /llms-full.txt)
-// Also support libraries with local paths starting with / (served from current server)
-const libsEntries = Object.entries(libs).filter(
-  ([, lib]) => lib.docs_url.includes('pmndrs.github.io') || lib.docs_url.startsWith('/'),
-)
+// Only support libraries whose site actually publishes a /llms-full.txt dump -- see
+// the `llms_full` flag in `src/app/page.tsx`. Being hosted on pmndrs.github.io is not
+// enough: most of those sites are not built with this generator and 404 on that file,
+// which used to leave their index resource silently empty.
+const libsEntries = Object.entries(libs).filter(([, lib]) => 'llms_full' in lib && lib.llms_full)
 const libraryList = libsEntries.map(([libname]) => `- ${libname}`).join('\n')
 
 async function baseUrl() {
@@ -48,7 +48,9 @@ This MCP (Model Context Protocol) server provides programmatic access to documen
 
 ## Supported Libraries
 
-The server supports all pmndrs ecosystem libraries including:
+The server supports the pmndrs libraries whose documentation site publishes a
+full-text dump. That is these, and only these -- any other pmndrs library is out of
+scope here, however well known:
 ${libraryList}
 
 ## Available Resources
@@ -57,21 +59,19 @@ ${libraryList}
 This manifest - provides an overview of the server, its capabilities, and usage guidelines.
 
 ### 2. \`docs://{lib}/index\`
-Index of available documentation pages for each library. Each library has its own index resource:
-- \`docs://zustand/index\` - Zustand documentation index
-- \`docs://jotai/index\` - Jotai documentation index
-- \`docs://valtio/index\` - Valtio documentation index
-- And similarly for all other supported libraries
+Index of available documentation pages for each library -- one resource per supported library, e.g. \`docs://zustand/index\` or \`docs://drei/index\`.
 
 **Output format:**
 Each line contains: \`{page_path} - {page_title}\`
 
-**Example:**
+**Example** (from \`docs://zustand/index\`):
 \`\`\`
-/docs/guides/typescript - TypeScript Guide
-/docs/api/create - create API
-/docs/guides/auto-generating-selectors - Auto-generating Selectors
+/learn/getting-started/introduction - Introduction
+/learn/guides/beginner-typescript - Beginner TypeScript Guide
+/reference/apis/create - create
 \`\`\`
+
+Path shapes differ per library -- zustand nests under \`/learn\` and \`/reference\`, react-three-fiber under \`/api\` and \`/tutorials\`, drei under \`/abstractions\` and \`/staging\`. Read the index, never extrapolate a path from another library.
 
 ## Available Tools
 
@@ -80,15 +80,17 @@ Retrieves the full content of a specific documentation page.
 
 **Input:**
 - \`lib\` (string): The library name
-- \`path\` (string): The page path (e.g., "/docs/guides/typescript")
+- \`path\` (string): A page path taken verbatim from that library's index (e.g., "/learn/guides/beginner-typescript")
 
 **Output:**
 - The full markdown content of the requested page
 
 **Example usage:**
 \`\`\`
-Use get_page_content with lib="zustand" and path="/docs/guides/typescript" to get the TypeScript guide
+Use get_page_content with lib="zustand" and path="/learn/guides/beginner-typescript" to get the beginner TypeScript guide
 \`\`\`
+
+Paths are matched exactly -- no trailing-slash or extension normalization. A path that is not in the index returns \`Page not found\`; re-read the index rather than retrying variants.
 
 ## Best Practices
 
@@ -104,7 +106,7 @@ Use get_page_content with lib="zustand" and path="/docs/guides/typescript" to ge
 
 ### Working with Libraries
 1. Library names are **case-sensitive** (use exact names as listed above)
-2. Internal routes (like \`/zustand\`) are automatically resolved to \`https://docs.pmnd.rs/zustand\`
+2. A library configured with a local \`docs_url\` is served from this host
 3. External library documentation is fetched from their respective domains
 
 ## Error Handling
@@ -144,7 +146,7 @@ Resources use the \`docs://\` URI scheme:
 
 ## Getting Started
 
-1. Connect to the server at \`https://docs.pmnd.rs/api/sse\`
+1. Connect to the server at \`https://docs.pmnd.rs/api/mcp\` (or \`/api/sse\` for the legacy SSE transport)
 2. Read \`docs://pmndrs/manifest\` to understand server capabilities
 3. Access \`docs://{lib}/index\` to discover available documentation for a library
 4. Request specific pages with \`get_page_content\` tool
@@ -157,11 +159,11 @@ Resources use the \`docs://\` URI scheme:
 
 2. Agent thinks: I should check what Zustand documentation is available
    → Read resource docs://zustand/index
-   → Discover there's a "/docs/guides/typescript - TypeScript Guide" page
+   → Discover there's a "/learn/guides/beginner-typescript - Beginner TypeScript Guide" page
 
 3. Agent retrieves content:
-   → Call tool get_page_content(lib="zustand", path="/docs/guides/typescript")
-   
+   → Call tool get_page_content(lib="zustand", path="/learn/guides/beginner-typescript")
+
 4. Agent synthesizes answer from the documentation content
 \`\`\`
 
@@ -204,6 +206,13 @@ Resources use the \`docs://\` URI scheme:
               tags: [`llms-full-${libname}`],
             },
           })
+          // Fail loudly: an unchecked 404 yields an empty index, which reads to a
+          // client as "this library has no pages" and invites it to guess paths
+          if (!response.ok) {
+            throw new Error(
+              `MCP server error: Failed to fetch ${url}/llms-full.txt: ${response.statusText}`,
+            )
+          }
           const fullText = await response.text()
           const $ = cheerio.load(fullText, { xmlMode: true })
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -255,7 +255,7 @@ export default function Page() {
                 className="group/card bg-surface-container relative overflow-hidden rounded-md border border-outline-variant font-normal"
               >
                 <div className="relative z-10 flex h-full flex-col justify-between">
-                  <div className="flex items-center justify-between gap-6 px-6 py-6">
+                  <div className="flex items-start justify-between gap-6 px-6 py-6">
                     <div className="max-w-md">
                       <div className="flex items-center gap-2">
                         <div className="text-lg font-bold">{data.title}</div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,6 +26,10 @@ export interface Library {
   icon?: string
   iconWidth?: number
   iconHeight?: number
+  // Whether `${docs_url}/llms-full.txt` exists, i.e. the site is built with this
+  // generator. Only these libraries can be served over MCP -- see
+  // `src/app/api/[transport]/route.ts`. Flip it on once a site ships its dump.
+  llms_full?: boolean
 }
 
 export const libs = {
@@ -34,6 +38,7 @@ export const libs = {
     docs_url: 'https://pmndrs.github.io/react-three-fiber',
     github: 'https://github.com/pmndrs/react-three-fiber',
     description: 'React-three-fiber is a React renderer for three.js',
+    llms_full: true,
     icon: r3fIcon.src,
     iconWidth: r3fIcon.width,
     iconHeight: r3fIcon.height,
@@ -53,6 +58,7 @@ export const libs = {
     github: 'https://github.com/pmndrs/drei',
     description:
       'Drei is a growing collection of useful helpers and abstractions for react-three-fiber',
+    llms_full: true,
     icon: dreiIcon.src,
     iconWidth: dreiIcon.width,
     iconHeight: dreiIcon.height,
@@ -63,6 +69,7 @@ export const libs = {
     github: 'https://github.com/pmndrs/zustand',
     description:
       'Zustand is a small, fast and scalable bearbones state-management solution, it has a comfy api based on hooks',
+    llms_full: true,
     icon: zustandIcon.src,
     iconWidth: zustandIcon.width,
     iconHeight: zustandIcon.height,
@@ -118,6 +125,7 @@ export const libs = {
     docs_url: '/getting-started/introduction',
     github: 'https://github.com/pmndrs/docs',
     description: 'Documentation generator for `pmndrs/*`',
+    llms_full: true,
     icon: docsIcon.src,
     iconWidth: docsIcon.width,
     iconHeight: docsIcon.height,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,7 @@ import zustandIcon from '@/assets/zustand-icon.svg'
 import Icon from '@/components/Icon'
 import { Code } from '@/components/mdx/Code/Code'
 import { Gha } from '@/components/mdx/Gha/Gha'
+import { Badge } from '@/components/ui/badge'
 import { svg } from '@/utils/icon'
 import { Metadata } from 'next'
 import Image from 'next/image'
@@ -256,7 +257,17 @@ export default function Page() {
                 <div className="relative z-10 flex h-full flex-col justify-between">
                   <div className="flex items-center justify-between gap-6 px-6 py-6">
                     <div className="max-w-md">
-                      <div className="text-lg font-bold">{data.title}</div>
+                      <div className="flex items-center gap-2">
+                        <div className="text-lg font-bold">{data.title}</div>
+                        {'llms_full' in data && data.llms_full && (
+                          <Badge
+                            variant="secondary"
+                            title={`Reachable from an MCP client as lib="${id}"`}
+                          >
+                            MCP
+                          </Badge>
+                        )}
+                      </div>
                       <div className="grow text-sm leading-relaxed! text-on-surface-variant/50">
                         {data.description}
                       </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -148,7 +148,7 @@ export const libs = {
     github: 'https://github.com/pmndrs/leva',
     description: 'React-first components GUI',
   },
-} as const
+} as const satisfies Record<string, Library>
 
 export type SUPPORTED_LIBRARY_NAMES = keyof typeof libs
 

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react'
+import { cva, type VariantProps } from 'class-variance-authority'
+
+import { cn } from '@/lib/utils'
+
+const badgeVariants = cva(
+  'inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  {
+    variants: {
+      variant: {
+        default: 'border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/80',
+        secondary:
+          'border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        destructive:
+          'border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80',
+        outline: 'text-foreground',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return <div className={cn(badgeVariants({ variant }), className)} {...props} />
+}
+
+export { Badge, badgeVariants }

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 
 const badgeVariants = cva(
-  'inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  'inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-full border px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
   {
     variants: {
       variant: {

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -8,11 +8,14 @@ const badgeVariants = cva(
   {
     variants: {
       variant: {
-        default: 'border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/80',
+        // [a&]: so the hover state only exists when the badge is rendered as a link.
+        // A plain badge is a label, not a control, and must not react to the pointer.
+        default:
+          'border-transparent bg-primary text-primary-foreground shadow [a&]:hover:bg-primary/90',
         secondary:
-          'border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80',
+          'border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90',
         destructive:
-          'border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80',
+          'border-transparent bg-destructive text-destructive-foreground shadow [a&]:hover:bg-destructive/90',
         outline: 'text-foreground',
       },
     },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,9 @@ import path from 'path'
 export default defineConfig({
   resolve: {
     alias: {
+      // Mirrors the tsconfig `paths`. Must come before the `@` prefix alias, which
+      // would otherwise resolve this to src/package.json and fail to import ./route.
+      '@/package.json': path.resolve(__dirname, './package.json'),
       '@': path.resolve(__dirname, './src'),
     },
   },


### PR DESCRIPTION
Found while wiring `https://docs.pmnd.rs/api/mcp` into a Claude Code plugin: the server advertises 11 libraries and can only serve 4.

## The bug

Libraries were selected by testing whether `docs_url` is on `pmndrs.github.io`, as a proxy for "built with this generator, therefore ships a `/llms-full.txt`". The proxy is wrong for 7 of the 11 it lets through — probed just now against production:

| library | `${docs_url}/llms-full.txt` | `<page>` elements |
|---|---|---|
| react-three-fiber | 200 | 20 |
| drei | 200 | 134 |
| zustand | 200 | 42 |
| docs | 200 | 16 |
| a11y | **404** | 0 |
| react-postprocessing | **404** | 0 |
| uikit | **404** | 0 |
| xr | **404** | 0 |
| prai | **404** | 0 |
| viverse | **404** | 0 |
| leva | **404** | 0 |

Those 7 are non-functional today on **both** entry points — but only one of them says so:

```
get_page_content(lib="leva", …)  →  MCP server error: Failed to fetch llms-full.txt: Not Found
read docs://leva/index           →  ""     ← silent
```

`get_page_content` checks `response.ok`. The index resource did not, so the 404 body parsed to zero `<page>` elements and shipped an empty index. A client reads that as *"this library has no documentation pages"* — which is an invitation to guess paths. Every guess then fails with `Page not found: /x`, which points at the path rather than at the missing dump. That is a long way to walk from a 404.

## The fix

- **`page.tsx`** — an explicit `llms_full?: boolean` on the four libraries whose sites publish a dump. Flip it on as each of the others ships one; that is a fact maintainers know and the URL cannot tell you. No second list: it is one field on the existing `libs`, which stays the single source of truth.
- **`route.ts`** — select on that flag, and check `response.ok` in the index resource too, so a missing dump fails loudly on both paths.

Nothing is lost: the 7 dropped libraries return errors or empty strings today.

`libs` was also declared `as const` with no annotation, so `Library` was decorative — `llms_ful: true` would have compiled and silently dropped a library from MCP. It is now `as const satisfies Record<string, Library>`, which keeps the literal types and makes that a type error.

## On the home page

The page lists fourteen libraries and the server can serve four; nothing said which, so the only way to find out was to ask and get an empty index back. Each servable card now carries an `MCP` badge, read from the same `llms_full` flag the enum filters on — so the page and the server cannot disagree, and a library gets its badge on the commit that makes it servable.

Uses shadcn's `Badge`, which the repo was already set up for (`components.json`, the token block in `globals.css`, `cn()` in `lib/utils`), so it pulls in **no new dependency**. Checked in both colour schemes.

⚠️ This changes the home page snapshot — the Chromatic baselines will need accepting.

## Manifest

`docs://pmndrs/manifest` was sending clients down the same road, so it is corrected in the same pass:

- advertised `docs://jotai/index` and `docs://valtio/index` — neither is served (both are filtered out; their docs live off-pmndrs)
- every example used zustand paths under `/docs/...` that 404. The real ones are `/learn/...` and `/reference/...`. Path shapes differ per library — r3f uses `/api` and `/tutorials`, drei `/abstractions` and `/staging` — so the manifest now says to read the index rather than extrapolate from another library
- claimed local `docs_url`s resolve to `https://docs.pmnd.rs/<lib>`; the code discards the path and uses the host
- pointed "Getting Started" at `/api/sse` while the homepage advertises `/api/mcp`

## Tests

`vitest.config.ts` was missing the `@/package.json` alias that `tsconfig.json` has, so `import('./route')` threw `Cannot find package` — **the one test that actually imports the route has been failing on `main`**, and passing anyway, because it only asserts `toBeDefined()`. Alias added; that test now genuinely runs.

Which exposed the next layer: once it ran, it went to the real `pmndrs.github.io`. The MSW handlers mock `r3f.docs.pmnd.rs` and `zustand.docs.pmnd.rs` — hosts the route never requests — and `onUnhandledRequest` was `'warn'`. The suite is now hermetic:

- handlers derived from `libs`, the same source of truth the route reads, so mocks cannot drift from the real `docs_url`s
- `onUnhandledRequest: 'error'` — any future unmocked call fails instead of opening a socket
- that test asserts on the returned page content, not `toBeDefined()`, which an error response satisfies just as well. Comment out the handlers and it goes red, which is the point

On top of that, `Library Filtering` re-implemented the old filter inline and asserted on the copy, so it would have kept passing after this change. It now asserts against the real `libs` export, including the 7 pmndrs.github.io libraries that must stay excluded.

New regression test: a 404 on `llms-full.txt` must produce an error, not an empty index.

```
Before (main):  Tests  1 failed | 76 passed (77)
After:          Tests  78 passed (78)
```

`tsc --noEmit` and `eslint` are clean.

## No changeset

Per the README policy this is a site-only change — it touches the deployed API route, not the reusable workflow, build behavior or templates that consumers pin `@v3` for.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
