### PR TITLE
Lead the MCP callout with the claude-code plugin

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -194,13 +194,30 @@ export default function Page() {
                 >
                   MCP-compatible client
                 </a>
-                , e.g. claude-code :
+                .
               </div>
+              <p className="mt-4 text-sm leading-relaxed!">
+                In claude-code, the{' '}
+                <a
+                  href="https://github.com/pmndrs/claude-code-plugin"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline"
+                >
+                  pmndrs plugin
+                </a>{' '}
+                installs this server together with a skill telling Claude to look the docs up rather
+                than recall an API from memory :
+              </p>
               <Code className="language-bash">
-                <code className="language-bash">{`claude mcp add --transport http pmndrs https://docs.pmnd.rs/api/mcp`}</code>
+                <code className="language-bash">{`/plugin marketplace add pmndrs/claude-code-plugin
+/plugin install pmndrs@pmndrs`}</code>
               </Code>
               <details className="text-sm">
-                <summary className="cursor-pointer">Other clients (JSON config)</summary>
+                <summary className="cursor-pointer">Server on its own, for any client</summary>
+                <Code className="language-bash">
+                  <code className="language-bash">{`claude mcp add --transport http pmndrs https://docs.pmnd.rs/api/mcp`}</code>
+                </Code>
                 <Code className="language-json">
                   <code className="language-json">{`{
   "mcpServers": {


### PR DESCRIPTION
> [!IMPORTANT]
> **Draft — do not merge before pmndrs/claude-code-plugin#7.** On that repo's `main` today the plugin ships **zero components**: no `.mcp.json`, no `skills/`. `/plugin install pmndrs@pmndrs` succeeds and installs an empty shell. This page must not send people there until #7 lands.

## Why lead with the plugin

`claude mcp add` puts the tools in reach and stops there. In practice Claude keeps answering react-three-fiber and drei questions from memory — which is the problem this server exists to solve, since those APIs move faster than any training cutoff.

The plugin ships the same server plus a skill whose whole job is to send Claude to the docs before it answers. Same endpoint, one command, and it carries whatever the plugin gains later.

## Why the raw config stays

The plugin is claude-code only. Replacing the existing block outright would shut the door on Cursor, Zed, VS Code and every other MCP client, which is why the command and the JSON config move into the `<details>` rather than out of the page:

```
claude-code   →  /plugin marketplace add pmndrs/claude-code-plugin
                 /plugin install pmndrs@pmndrs

any client    →  claude mcp add … / JSON config     (unchanged, one fold down)
```

Both blocks keep their copy button; checked open and closed, in both colour schemes.

## Not stacked on #555

Branched from `main`, so it is independent of pmndrs/docs#555 — that one fixes a server coverage bug and has no business carrying this. The only ordering constraint is #7.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
