### PR TITLE
Point claude-code users at the plugin instead of the raw MCP add

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -206,7 +206,8 @@ export default function Page() {
                 , e.g. claude-code :
               </div>
               <Code className="language-bash">
-                <code className="language-bash">{`claude mcp add --transport http pmndrs https://docs.pmnd.rs/api/mcp`}</code>
+                <code className="language-bash">{`/plugin marketplace add pmndrs/claude-code-plugin
+/plugin install pmndrs@pmndrs`}</code>
               </Code>
               <details className="text-sm">
                 <summary className="cursor-pointer">Other clients (JSON config)</summary>


### PR DESCRIPTION
The homepage told claude-code users to wire the MCP server up by hand. There is now a plugin that does it for them, so the tip block shows the two `/plugin` commands instead. The JSON config stays for every other client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HLvyZEqwZ9S6VdAYBsNbWX