### PR TITLE
Serve the example gallery over MCP, next to the docs

### DIFF
--- a/.changeset/examples-over-mcp.md
+++ b/.changeset/examples-over-mcp.md
@@ -1,0 +1,5 @@
+---
+'@pmndrs/docs': minor
+---
+
+Serve the pmndrs example gallery over MCP, next to the docs: an `examples://index` resource listing every published demo with its description, libraries and tags, and a `get_example` tool returning one demo in full -- source files, the dependency versions it is written against, and asset attribution. Reads the JSON catalog pmndrs/examples publishes at `/catalog/`; override the origin with `EXAMPLES_URL` to develop against a local build.

--- a/src/app/api/[transport]/route.test.ts
+++ b/src/app/api/[transport]/route.test.ts
@@ -41,9 +41,60 @@ const llmsFullHandlers = Object.values(libs)
     return http.get(`${origin}/llms-full.txt`, () => HttpResponse.text(mockLlmsFullTxt))
   })
 
+// The examples catalog, as pmndrs/examples publishes it -- an index to pick from
+// and one file per example. Two entries is enough to tell "served the index" from
+// "served an example"; `src/utils/examples.test.ts` covers the rendering itself.
+const mockExampleIndex = {
+  site: 'https://pmndrs.github.io/examples',
+  count: 2,
+  examples: [
+    {
+      name: 'caustics',
+      title: 'Caustics',
+      description: '',
+      tags: ['transmission'],
+      authors: ['Paul Henschel'],
+      libraries: ['@react-three/drei', '@react-three/fiber'],
+      source: 'https://codesandbox.io/s/szj6p7',
+      demo: 'https://pmndrs.github.io/examples/examples/caustics',
+      thumbnail: 'https://pmndrs.github.io/examples/caustics/thumbnail.webp',
+    },
+    {
+      name: 'arkanoid',
+      title: 'Arkanoid',
+      description: 'Simple arkanoid implementation using cannon physics.',
+      tags: ['physics', 'game'],
+      authors: ['Paul Henschel'],
+      libraries: ['@react-three/fiber', '@react-three/cannon'],
+      source: 'https://codesandbox.io/s/arkanoid',
+      demo: 'https://pmndrs.github.io/examples/examples/arkanoid',
+      thumbnail: 'https://pmndrs.github.io/examples/arkanoid/thumbnail.webp',
+    },
+  ],
+}
+
+const mockExample = {
+  ...mockExampleIndex.examples[0],
+  repository: 'https://github.com/pmndrs/examples/tree/main/examples/caustics',
+  install: 'npx degit pmndrs/examples/examples/caustics',
+  dependencies: { '@react-three/drei': '10.7.8' },
+  files: [{ path: 'src/App.tsx', content: 'const caustics = true' }],
+  binaries: ['src/glass-transformed.glb'],
+  oversized: [],
+  assets: [],
+}
+
 // Setup MSW server
 const server = setupServer(
   ...llmsFullHandlers,
+
+  http.get('https://pmndrs.github.io/examples/catalog/index.json', () =>
+    HttpResponse.json(mockExampleIndex),
+  ),
+
+  http.get('https://pmndrs.github.io/examples/catalog/caustics.json', () =>
+    HttpResponse.json(mockExample),
+  ),
 
   // Hosts the standalone fetch-and-parse tests below call directly
   http.get('https://r3f.docs.pmnd.rs/llms-full.txt', () => {
@@ -483,6 +534,72 @@ Content with &lt;special&gt; characters &amp; symbols.
       const page = $('page').filter((_, el) => $(el).attr('path') === maliciousPath)
 
       expect(page.length).toBe(0)
+    })
+  })
+
+  describe('Examples', () => {
+    async function call(method: string, params: unknown) {
+      const { POST } = await import('./route')
+      const response = await POST(
+        new Request('https://docs.pmnd.rs/api/mcp', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json, text/event-stream',
+          },
+          body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+        }),
+      )
+      return response.text()
+    }
+
+    it('serves the whole gallery as one line per example', async () => {
+      const body = await call('resources/read', { uri: 'examples://index' })
+
+      expect(body).toContain('caustics · #transmission')
+      expect(body).toContain(
+        'arkanoid · Simple arkanoid implementation using cannon physics. · +cannon · #physics,game',
+      )
+      expect(body).not.toContain('MCP server error')
+    })
+
+    it('serves one example with its source', async () => {
+      const body = await call('tools/call', {
+        name: 'get_example',
+        arguments: { name: 'caustics' },
+      })
+
+      expect(body).toContain('# Caustics')
+      expect(body).toContain('const caustics = true')
+      expect(body).toContain('Dependencies: @react-three/drei@10.7.8')
+      // Named, not inlined -- a reader that needs the model knows where it is
+      expect(body).toContain('src/glass-transformed.glb')
+      expect(body).not.toContain('MCP server error')
+    })
+
+    it.each(['../../../etc/passwd', 'index'])(
+      'refuses %j without reaching for a URL',
+      async (name) => {
+        // No msw handler exists for whatever this would resolve to, and the server
+        // runs with onUnhandledRequest: 'error' -- so a fetch here fails the test on
+        // its own, and the assertion below is about the message a client gets.
+        const body = await call('tools/call', { name: 'get_example', arguments: { name } })
+
+        expect(body).toContain('Not an example name')
+      },
+    )
+
+    it('errors, rather than serving an empty gallery, when the catalog is missing', async () => {
+      server.use(
+        http.get('https://pmndrs.github.io/examples/catalog/index.json', () => {
+          return new HttpResponse('Not Found', { status: 404 })
+        }),
+      )
+
+      const body = await call('resources/read', { uri: 'examples://index' })
+
+      expect(body).toContain('Failed to fetch')
+      expect(body).not.toContain('"text":""')
     })
   })
 })

--- a/src/app/api/[transport]/route.test.ts
+++ b/src/app/api/[transport]/route.test.ts
@@ -58,6 +58,7 @@ const mockExampleIndex = {
       source: 'https://codesandbox.io/s/szj6p7',
       demo: 'https://pmndrs.github.io/examples/examples/caustics',
       thumbnail: 'https://pmndrs.github.io/examples/caustics/thumbnail.webp',
+      bytes: 4_000,
     },
     {
       name: 'arkanoid',
@@ -69,6 +70,7 @@ const mockExampleIndex = {
       source: 'https://codesandbox.io/s/arkanoid',
       demo: 'https://pmndrs.github.io/examples/examples/arkanoid',
       thumbnail: 'https://pmndrs.github.io/examples/arkanoid/thumbnail.webp',
+      bytes: 90_000,
     },
   ],
 }
@@ -556,9 +558,10 @@ Content with &lt;special&gt; characters &amp; symbols.
     it('serves the whole gallery as one line per example', async () => {
       const body = await call('resources/read', { uri: 'examples://index' })
 
+      // caustics' fixture is under the size threshold and arkanoid's is over it
       expect(body).toContain('caustics · #transmission')
       expect(body).toContain(
-        'arkanoid · Simple arkanoid implementation using cannon physics. · +cannon · #physics,game',
+        'arkanoid · Simple arkanoid implementation using cannon physics. · +cannon · #physics,game · ~23k',
       )
       expect(body).not.toContain('MCP server error')
     })

--- a/src/app/api/[transport]/route.ts
+++ b/src/app/api/[transport]/route.ts
@@ -5,6 +5,14 @@ import { headers } from 'next/headers'
 import { revalidateTag } from 'next/cache'
 import { libs, type SUPPORTED_LIBRARY_NAMES } from '@/app/page'
 import packageJson from '@/package.json' with { type: 'json' }
+import {
+  assertExampleName,
+  catalogUrl,
+  renderExample,
+  renderIndex,
+  type Example,
+  type ExampleIndex,
+} from '@/utils/examples'
 
 // Extract entries and library names as constants for efficiency
 // Only support libraries whose site actually publishes a /llms-full.txt dump -- see
@@ -20,6 +28,23 @@ async function baseUrl() {
 
   const protocol = host.includes('localhost') ? 'http' : 'https'
   return `${protocol}://${host}`
+}
+
+/**
+ * One file out of the examples catalog. Cached and tagged like the docs dumps,
+ * except the catalog is already split per example, so a request pulls the ~20 kB
+ * that was asked for rather than slicing it out of a bundle.
+ */
+async function fetchCatalog<T>(file: string): Promise<T> {
+  const response = await fetch(catalogUrl(file), {
+    next: { revalidate: 300, tags: ['examples-catalog'] },
+  })
+  // Same reason the library indexes fail loudly: a swallowed 404 reads to a
+  // client as "no such example", and it will go on to invent one.
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${catalogUrl(file)}: ${response.statusText}`)
+  }
+  return response.json() as Promise<T>
 }
 
 const handler = createMcpHandler(
@@ -45,6 +70,8 @@ const handler = createMcpHandler(
 ## Overview
 
 This MCP (Model Context Protocol) server provides programmatic access to documentation for all pmndrs libraries through surgical queries. It enables AI agents to efficiently retrieve specific documentation pages without downloading entire sites.
+
+It serves two bodies of material, and they answer different questions. The **docs** say what an API is -- signatures, props, options; the **examples** show a working scene that already does the thing, in full, with the versions it was written against. Reach for an example when the question is "how is this put together", for the docs when it is "what does this take".
 
 ## Supported Libraries
 
@@ -73,6 +100,23 @@ Each line contains: \`{page_path} - {page_title}\`
 
 Path shapes differ per library -- zustand nests under \`/learn\` and \`/reference\`, react-three-fiber under \`/api\` and \`/tutorials\`, drei under \`/abstractions\` and \`/staging\`. Read the index, never extrapolate a path from another library.
 
+### 3. \`examples://index\`
+The whole pmndrs example gallery (https://pmndrs.github.io/examples), one line per demo. About 4k tokens for all of them, so read it once and pick from it -- there is no per-library or per-tag variant.
+
+**Output format:**
+\`\`\`
+{name} [({title}, when it is not just the name)] · {description} · +{libraries} · #{tags}
+\`\`\`
+
+Every part after the name is dropped when the example does not carry it:
+\`\`\`
+aquarium · #transmission
+arkanoid · Simple arkanoid implementation using cannon physics. · +cannon,zustand · #physics,game,audio
+bounds-and-makedefault (Bounds and makeDefault) · #bounds
+\`\`\`
+
+\`+\` lists only what an example uses *on top of* \`@react-three/fiber\` and \`@react-three/drei\`, which all of them use. Tags are freeform and unvalidated -- expect typos (\`gtlf\`) and both spellings of an idea (\`contact shadows\` / \`contact-shadows\`) -- so match on names and descriptions too, never on tags alone.
+
 ## Available Tools
 
 ### 1. \`get_page_content\`
@@ -92,12 +136,29 @@ Use get_page_content with lib="zustand" and path="/learn/guides/beginner-typescr
 
 Paths are matched exactly -- no trailing-slash or extension normalization. A path that is not in the index returns \`Page not found\`; re-read the index rather than retrying variants.
 
+### 2. \`get_example\`
+Retrieves one example in full: description, demo URL, authors, asset attribution, the exact dependency versions it is written against, and every source file it has.
+
+**Input:**
+- \`name\` (string): An example name taken verbatim from \`examples://index\` (e.g., "caustics")
+
+**Output:**
+- Markdown: a fact block, then one fenced section per source file
+
+**Example usage:**
+\`\`\`
+Use get_example with name="caustics" to read the caustics demo end to end
+\`\`\`
+
+Typically 300-2k tokens, up to ~23k for the largest multi-file example. Two kinds of file are named rather than inlined: binary companions (.glb models, textures, audio), and text that is generated or vendored past the point of being readable (bundles, font atlases). Both are in the repository the response links to.
+
 ## Best Practices
 
 ### Efficient Querying
 1. **Always start with library index resources** (e.g., \`docs://zustand/index\`) to discover available documentation before requesting specific pages
 2. **Use resource URIs** to access page indexes - they're more efficient than tool calls for listing content
 3. **Use specific page paths** rather than trying to guess URLs
+4. **Read one example, not five.** Narrow on the index first; \`get_example\` is the expensive call
 
 ### Understanding the Content
 1. Documentation is returned as **raw markdown text**
@@ -114,15 +175,16 @@ Paths are matched exactly -- no trailing-slash or extension normalization. A pat
 The server provides clear error messages for common issues:
 - **Unknown library**: The specified library name doesn't exist
 - **Page not found**: The requested path doesn't exist for that library
+- **Not an example name**: \`get_example\` was given something that is not a published example; re-read \`examples://index\`
 - **Network errors**: Connectivity issues fetching documentation
 
 Always handle errors gracefully and consider alternative approaches when a specific page isn't available.
 
 ## Resource URI Scheme
 
-Resources use the \`docs://\` URI scheme:
 - \`docs://pmndrs/manifest\` - This manifest document
 - \`docs://{lib}/index\` - Page index for each library (e.g., \`docs://zustand/index\`)
+- \`examples://index\` - The example gallery, all of it
 
 ## Technical Notes
 
@@ -132,6 +194,8 @@ Resources use the \`docs://\` URI scheme:
   SSE transport would need a Redis instance to relay messages, which this deployment
   does not have, so \`/api/sse\` is not usable.
 - Documentation is parsed from XML-tagged full-text dumps (\`/llms-full.txt\`)
+- Examples come from the JSON catalog the gallery publishes at
+  \`https://pmndrs.github.io/examples/catalog/\`, already split one file per example
 
 ### Security
 - CSS selector injection protection via \`.filter()\` instead of direct selectors
@@ -166,6 +230,21 @@ Resources use the \`docs://\` URI scheme:
    → Call tool get_page_content(lib="zustand", path="/learn/guides/beginner-typescript")
 
 4. Agent synthesizes answer from the documentation content
+\`\`\`
+
+\`\`\`
+1. User asks: "How do I make glass refract in r3f?"
+
+2. Agent thinks: someone has almost certainly built this already
+   → Read resource examples://index
+   → Several lines carry #transmission; "aquarium" and "caustics" look closest
+
+3. Agent retrieves one of them:
+   → Call tool get_example(name="caustics")
+
+4. Agent has a working scene, and the drei version it was written against. If the
+   answer turns on an API's current shape, it checks that against docs://drei/index
+   rather than assuming the example is up to date.
 \`\`\`
 
 ## Notes
@@ -235,6 +314,32 @@ Resources use the \`docs://\` URI scheme:
     }
 
     //
+    // Register the examples index
+    //
+
+    server.registerResource(
+      'pmndrs examples index',
+      'examples://index',
+      {
+        description:
+          'The pmndrs example gallery: every published demo, one per line, with what it shows and what it is built with.',
+        mimeType: 'text/plain',
+      },
+      async () => {
+        const index = await fetchCatalog<ExampleIndex>('index')
+
+        return {
+          contents: [
+            {
+              uri: 'examples://index',
+              text: renderIndex(index),
+            },
+          ],
+        }
+      },
+    )
+
+    //
     // Register get_page_content tool
     //
 
@@ -282,6 +387,43 @@ Resources use the \`docs://\` URI scheme:
               {
                 type: 'text',
                 text: page.text().trim(),
+              },
+            ],
+          }
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : String(error)
+          throw new Error(`MCP server error: ${errorMessage}`)
+        }
+      },
+    )
+
+    //
+    // Register get_example tool
+    //
+
+    server.registerTool(
+      'get_example',
+      {
+        title: 'Get Example',
+        description:
+          'Get a pmndrs example in full: what it demonstrates, the versions it is written against, and every source file.',
+        inputSchema: {
+          name: z
+            .string()
+            .describe('An example name taken verbatim from the examples://index resource'),
+        },
+      },
+      async ({ name }) => {
+        try {
+          // The catalog is one file per example, so `name` reaches a URL. Keep it
+          // to the shape every published example has rather than trusting it.
+          const example = await fetchCatalog<Example>(assertExampleName(name))
+
+          return {
+            content: [
+              {
+                type: 'text',
+                text: renderExample(example),
               },
             ],
           }

--- a/src/app/api/[transport]/route.ts
+++ b/src/app/api/[transport]/route.ts
@@ -105,7 +105,7 @@ The whole pmndrs example gallery (https://pmndrs.github.io/examples), one line p
 
 **Output format:**
 \`\`\`
-{name} [({title}, when it is not just the name)] · {description} · +{libraries} · #{tags}
+{name} [({title}, when it is not just the name)] · {description} · +{libraries} · #{tags} · ~{size}
 \`\`\`
 
 Every part after the name is dropped when the example does not carry it:
@@ -113,9 +113,12 @@ Every part after the name is dropped when the example does not carry it:
 aquarium · #transmission
 arkanoid · Simple arkanoid implementation using cannon physics. · +cannon,zustand · #physics,game,audio
 bounds-and-makedefault (Bounds and makeDefault) · #bounds
+flow-shield · Interactive energy shield. · +postprocessing,leva · #shader · ~23k
 \`\`\`
 
 \`+\` lists only what an example uses *on top of* \`@react-three/fiber\` and \`@react-three/drei\`, which all of them use. Tags are freeform and unvalidated -- expect typos (\`gtlf\`) and both spellings of an idea (\`contact shadows\` / \`contact-shadows\`) -- so match on names and descriptions too, never on tags alone.
+
+The trailing \`~23k\` is what \`get_example\` will cost in tokens, and only eight lines carry one. Its absence means the example is small: the median is ~1.4k tokens, so reading two or three of them costs less than this index did. Read the marked ones deliberately, one at a time.
 
 ## Available Tools
 
@@ -158,7 +161,7 @@ Typically 300-2k tokens, up to ~23k for the largest multi-file example. Two kind
 1. **Always start with library index resources** (e.g., \`docs://zustand/index\`) to discover available documentation before requesting specific pages
 2. **Use resource URIs** to access page indexes - they're more efficient than tool calls for listing content
 3. **Use specific page paths** rather than trying to guess URLs
-4. **Read one example, not five.** Narrow on the index first; \`get_example\` is the expensive call
+4. **Let the index line say how many examples to open.** Unmarked ones are ~1.4k tokens, so reading the two that both look right beats fetching one and coming back; a \`~23k\` marker is the one case where it pays to narrow first
 
 ### Understanding the Content
 1. Documentation is returned as **raw markdown text**

--- a/src/utils/examples.test.ts
+++ b/src/utils/examples.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect } from 'vitest'
+import {
+  assertExampleName,
+  catalogUrl,
+  renderExample,
+  renderIndex,
+  summaryLine,
+  type Example,
+  type ExampleSummary,
+} from './examples'
+
+const summary = (over: Partial<ExampleSummary> = {}): ExampleSummary => ({
+  name: 'caustics',
+  title: 'Caustics',
+  description: '',
+  tags: [],
+  authors: ['Paul Henschel'],
+  libraries: ['@react-three/drei', '@react-three/fiber'],
+  source: 'https://codesandbox.io/s/szj6p7',
+  demo: 'https://pmndrs.github.io/examples/examples/caustics',
+  thumbnail: 'https://pmndrs.github.io/examples/caustics/thumbnail.webp',
+  ...over,
+})
+
+const example = (over: Partial<Example> = {}): Example => ({
+  ...summary(),
+  repository: 'https://github.com/pmndrs/examples/tree/main/examples/caustics',
+  install: 'npx degit pmndrs/examples/examples/caustics',
+  dependencies: { '@react-three/drei': '10.7.8', three: '0.165.0' },
+  files: [{ path: 'src/App.tsx', content: 'export default function App() {}' }],
+  binaries: [],
+  oversized: [],
+  assets: [],
+  ...over,
+})
+
+describe('summaryLine', () => {
+  it('drops a title that is just the prettified name', () => {
+    expect(summaryLine(summary())).toBe('caustics')
+  })
+
+  it('keeps a title that carries something the name cannot', () => {
+    expect(
+      summaryLine(summary({ name: 'bounds-and-makedefault', title: 'Bounds and makeDefault' })),
+    ).toBe('bounds-and-makedefault (Bounds and makeDefault)')
+  })
+
+  it('omits fiber and drei, which every example uses', () => {
+    const line = summaryLine(
+      summary({
+        libraries: ['@react-three/fiber', '@react-three/drei', '@react-three/cannon', 'zustand'],
+      }),
+    )
+
+    expect(line).toBe('caustics · +cannon,zustand')
+  })
+
+  it('collapses the react-spring entry points into one name', () => {
+    const line = summaryLine(
+      summary({ libraries: ['@react-spring/three', '@react-spring/web', '@react-spring/core'] }),
+    )
+
+    expect(line).toBe('caustics · +react-spring')
+  })
+
+  it('assembles description, libraries and tags in that order', () => {
+    const line = summaryLine(
+      summary({
+        name: 'arkanoid',
+        title: 'Arkanoid',
+        description: 'Simple arkanoid implementation using cannon physics.',
+        libraries: ['@react-three/fiber', '@react-three/cannon'],
+        tags: ['physics', 'game'],
+      }),
+    )
+
+    expect(line).toBe(
+      'arkanoid · Simple arkanoid implementation using cannon physics. · +cannon · #physics,game',
+    )
+  })
+
+  it('flattens a description that wraps', () => {
+    const line = summaryLine(summary({ description: 'One idea,\n  spread over lines.' }))
+
+    expect(line).toBe('caustics · One idea, spread over lines.')
+  })
+})
+
+describe('renderIndex', () => {
+  it('is one line per example', () => {
+    const text = renderIndex({
+      site: 'https://pmndrs.github.io/examples',
+      count: 2,
+      examples: [summary(), summary({ name: 'aquarium', title: 'Aquarium', tags: ['water'] })],
+    })
+
+    expect(text).toBe('caustics\naquarium · #water')
+  })
+})
+
+describe('assertExampleName', () => {
+  it('passes the shape every published example has', () => {
+    expect(assertExampleName('gltfjsx-400kb-drone')).toBe('gltfjsx-400kb-drone')
+  })
+
+  it.each(['../../etc/passwd', 'Caustics', 'a b', 'caustics/../index', '', 'caustics?x=1'])(
+    'rejects %j before it can reach a URL',
+    (name) => {
+      expect(() => assertExampleName(name)).toThrow(/Not an example name/)
+    },
+  )
+
+  it('rejects "index", which is the one name that collides with the catalog itself', () => {
+    // Legal kebab-case, same directory: it would fetch the index and then be
+    // rendered as an example with no title and no files.
+    expect(() => assertExampleName('index')).toThrow(/Not an example name/)
+  })
+
+  it('puts a name where the catalog publishes it', () => {
+    expect(catalogUrl('caustics')).toBe('https://pmndrs.github.io/examples/catalog/caustics.json')
+  })
+})
+
+describe('renderExample', () => {
+  it('leads with the title and the facts a reader needs', () => {
+    const text = renderExample(example({ description: 'Glass, and what it does to light.' }))
+
+    expect(text).toContain('# Caustics')
+    expect(text).toContain('Glass, and what it does to light.')
+    expect(text).toContain('Demo: https://pmndrs.github.io/examples/examples/caustics')
+    expect(text).toContain('Scaffold: npx degit pmndrs/examples/examples/caustics')
+    expect(text).toContain('Dependencies: @react-three/drei@10.7.8, three@0.165.0')
+  })
+
+  it('omits the facts an example does not carry', () => {
+    const text = renderExample(example({ authors: [], tags: [] }))
+
+    expect(text).not.toContain('Authors:')
+    expect(text).not.toContain('Tags:')
+  })
+
+  it('fences each file under its own path, tagged by extension', () => {
+    const text = renderExample(
+      example({
+        files: [
+          { path: 'src/App.tsx', content: 'const a = 1' },
+          { path: 'src/styles.css', content: 'body { margin: 0 }' },
+        ],
+      }),
+    )
+
+    expect(text).toContain('## src/App.tsx\n\n```tsx\nconst a = 1\n```')
+    expect(text).toContain('## src/styles.css\n\n```css\nbody { margin: 0 }\n```')
+  })
+
+  it('opens a longer fence than the backticks inside the file', () => {
+    // A file whose comments quote code would otherwise close the block early and
+    // hand the reader half a file plus whatever followed it as prose.
+    const text = renderExample(
+      example({ files: [{ path: 'src/App.tsx', content: '// ```tsx\nconst a = 1' }] }),
+    )
+
+    expect(text).toContain('````tsx\n// ```tsx\nconst a = 1\n````')
+  })
+
+  it('names the binaries rather than pretending they are not there', () => {
+    const text = renderExample(example({ binaries: ['src/glass-transformed.glb'] }))
+
+    expect(text).toContain('src/glass-transformed.glb')
+  })
+
+  it('says which files were skipped on size, and how big they are', () => {
+    const text = renderExample(
+      example({ oversized: [{ path: 'src/realism-effects/v2.js', bytes: 256656 }] }),
+    )
+
+    expect(text).toContain(
+      'Too large to inline, in the repository: src/realism-effects/v2.js (251 kB)',
+    )
+  })
+
+  it('carries asset attribution through', () => {
+    const text = renderExample(
+      example({
+        assets: [
+          {
+            name: 'Fruit Cake Slice',
+            creator: 'matousekfoto',
+            license: 'CC-BY-4.0',
+            source: 'https://sketchfab.com/3d-models/fruit-cake-slice',
+          },
+        ],
+      }),
+    )
+
+    expect(text).toContain('## Asset attribution')
+    expect(text).toContain(
+      '- Fruit Cake Slice — by matousekfoto — CC-BY-4.0 (https://sketchfab.com/3d-models/fruit-cake-slice)',
+    )
+  })
+})

--- a/src/utils/examples.test.ts
+++ b/src/utils/examples.test.ts
@@ -19,6 +19,7 @@ const summary = (over: Partial<ExampleSummary> = {}): ExampleSummary => ({
   source: 'https://codesandbox.io/s/szj6p7',
   demo: 'https://pmndrs.github.io/examples/examples/caustics',
   thumbnail: 'https://pmndrs.github.io/examples/caustics/thumbnail.webp',
+  bytes: 4_000,
   ...over,
 })
 
@@ -83,6 +84,22 @@ describe('summaryLine', () => {
     const line = summaryLine(summary({ description: 'One idea,\n  spread over lines.' }))
 
     expect(line).toBe('caustics · One idea, spread over lines.')
+  })
+
+  it('says nothing about size for an example that is cheap to open', () => {
+    // The marker has to stay rare to mean anything: its absence is the signal
+    // that a reader can open two of these without thinking about the budget.
+    expect(summaryLine(summary({ bytes: 24 * 1024 }))).toBe('caustics')
+  })
+
+  it('marks an example large enough that opening it is a decision', () => {
+    expect(summaryLine(summary({ bytes: 90_048 }))).toBe('caustics · ~23k')
+  })
+
+  it('puts the size last, after everything that helps choose', () => {
+    const line = summaryLine(summary({ description: 'A shield.', tags: ['shader'], bytes: 90_048 }))
+
+    expect(line).toBe('caustics · A shield. · #shader · ~23k')
   })
 })
 

--- a/src/utils/examples.ts
+++ b/src/utils/examples.ts
@@ -38,6 +38,7 @@ export interface ExampleSummary {
   source: string
   demo: string
   thumbnail: string
+  bytes: number
 }
 
 export interface ExampleIndex {
@@ -99,14 +100,24 @@ export function assertExampleName(name: string) {
 }
 
 /**
+ * Where an example stops being cheap. The median is 5 kB and nine tenths are
+ * under 15 kB, so reading three of them costs less than this index does -- the
+ * size is worth saying only for the handful where it changes the decision.
+ * Eight examples are over this line; two of them are most of the distance.
+ */
+const LARGE_BYTES = 24 * 1024
+
+/**
  * One index line. Everything past the name is optional and omitted when the
- * example does not carry it, so an entry costs what it is worth:
+ * example does not carry it, so an entry costs what it is worth -- and a line
+ * with no size marker is one you can open without thinking about it:
  *
  *     aquarium · #transmission
  *     arkanoid · Simple arkanoid implementation using cannon physics. · +cannon,zustand · #physics,game
  *     bounds-and-makedefault (Bounds and makeDefault) · #bounds
+ *     flow-shield · Interactive energy shield. · +postprocessing,leva · #shader · ~23k
  */
-export function summaryLine({ name, title, description, libraries, tags }: ExampleSummary) {
+export function summaryLine({ name, title, description, libraries, tags, bytes }: ExampleSummary) {
   // A title that is just the prettified directory name is noise -- but not
   // always: `makeDefault`, `GLTF`, `Bruno Simon's` only exist in the title.
   const head = title && title !== titleCase(name) ? `${name} (${title})` : name
@@ -120,6 +131,7 @@ export function summaryLine({ name, title, description, libraries, tags }: Examp
     description.trim().replace(/\s+/g, ' '),
     extras.length ? `+${extras.join(',')}` : '',
     tags.length ? `#${tags.join(',')}` : '',
+    bytes > LARGE_BYTES ? `~${Math.round(bytes / 4000)}k` : '',
   ]
     .filter(Boolean)
     .join(' · ')

--- a/src/utils/examples.ts
+++ b/src/utils/examples.ts
@@ -1,0 +1,210 @@
+/**
+ * Reads the catalog that pmndrs/examples publishes alongside its website
+ * (`bin/build-catalog.mjs` there), so the MCP server can serve the example
+ * gallery next to the docs.
+ *
+ * The docs are page dumps parsed out of one `llms-full.txt` per library; the
+ * examples are not. They arrive as JSON, already split into an index and one
+ * file per example, so nothing here has to parse or slice a bundle -- it only
+ * has to render the pieces as the text an agent reads.
+ */
+
+/**
+ * Where the gallery lives. Overridable so the MCP server can be developed against
+ * a local `pnpm build` of pmndrs/examples -- the catalog only exists once that
+ * repo has built, and pointing at production while changing its shape tests the
+ * old shape.
+ */
+export const EXAMPLES_URL = process.env.EXAMPLES_URL || 'https://pmndrs.github.io/examples'
+
+/** Every published example is a kebab-case directory name. Anything else is a typo. */
+const EXAMPLE_NAME = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
+
+/**
+ * `index` is legal kebab-case and sits in the same directory, so it would fetch
+ * the index and then be rendered as an example that has no title and no files.
+ */
+const RESERVED_NAME = 'index'
+
+export interface ExampleSummary {
+  name: string
+  title: string
+  description: string
+  tags: string[]
+  authors: string[]
+  publishedAt?: string
+  notes?: string
+  libraries: string[]
+  source: string
+  demo: string
+  thumbnail: string
+}
+
+export interface ExampleIndex {
+  site: string
+  count: number
+  examples: ExampleSummary[]
+}
+
+export interface Example extends ExampleSummary {
+  repository: string
+  install: string
+  dependencies: Record<string, string>
+  files: { path: string; content: string }[]
+  binaries: string[]
+  oversized: { path: string; bytes: number }[]
+  assets: {
+    name: string
+    files?: string[]
+    creator?: string
+    source?: string
+    license?: string
+    licenseUrl?: string
+    modified?: boolean
+    notes?: string
+  }[]
+}
+
+/**
+ * Every example depends on these, so spelling them out on 167 index lines says
+ * nothing. The per-example view lists the real dependencies, versions included.
+ */
+const IMPLIED_LIBRARIES = new Set(['@react-three/fiber', '@react-three/drei'])
+
+const SHORT_LIBRARY_NAMES: Record<string, string> = {
+  '@react-spring/core': 'react-spring',
+  '@react-spring/three': 'react-spring',
+  '@react-spring/web': 'react-spring',
+  '@use-gesture/react': 'use-gesture',
+}
+
+const shortenLibrary = (library: string) =>
+  SHORT_LIBRARY_NAMES[library] ?? library.replace(/^@react-three\//, '')
+
+const titleCase = (name: string) =>
+  name
+    .split('-')
+    .map((word) => word[0].toUpperCase() + word.slice(1))
+    .join(' ')
+
+export function catalogUrl(file: string, base = EXAMPLES_URL) {
+  return `${base}/catalog/${file}.json`
+}
+
+export function assertExampleName(name: string) {
+  if (!EXAMPLE_NAME.test(name) || name === RESERVED_NAME) {
+    throw new Error(`Not an example name: ${name}`)
+  }
+  return name
+}
+
+/**
+ * One index line. Everything past the name is optional and omitted when the
+ * example does not carry it, so an entry costs what it is worth:
+ *
+ *     aquarium · #transmission
+ *     arkanoid · Simple arkanoid implementation using cannon physics. · +cannon,zustand · #physics,game
+ *     bounds-and-makedefault (Bounds and makeDefault) · #bounds
+ */
+export function summaryLine({ name, title, description, libraries, tags }: ExampleSummary) {
+  // A title that is just the prettified directory name is noise -- but not
+  // always: `makeDefault`, `GLTF`, `Bruno Simon's` only exist in the title.
+  const head = title && title !== titleCase(name) ? `${name} (${title})` : name
+
+  const extras = [
+    ...new Set(libraries.filter((l) => !IMPLIED_LIBRARIES.has(l)).map(shortenLibrary)),
+  ]
+
+  return [
+    head,
+    description.trim().replace(/\s+/g, ' '),
+    extras.length ? `+${extras.join(',')}` : '',
+    tags.length ? `#${tags.join(',')}` : '',
+  ]
+    .filter(Boolean)
+    .join(' · ')
+}
+
+export function renderIndex({ examples }: ExampleIndex) {
+  return examples.map(summaryLine).join('\n')
+}
+
+const FENCE_LANGUAGES: Record<string, string> = {
+  '.ts': 'ts',
+  '.tsx': 'tsx',
+  '.js': 'js',
+  '.jsx': 'jsx',
+  '.mjs': 'js',
+  '.cjs': 'js',
+  '.css': 'css',
+  '.json': 'json',
+  '.glsl': 'glsl',
+  '.vert': 'glsl',
+  '.frag': 'glsl',
+}
+
+/** A fence long enough to survive whatever backticks the file itself contains. */
+function fence(content: string) {
+  const longest = Math.max(0, ...(content.match(/`+/g) ?? []).map((run) => run.length))
+  return '`'.repeat(Math.max(3, longest + 1))
+}
+
+function attribution(assets: Example['assets']) {
+  return assets
+    .map((asset) => {
+      const parts = [asset.name]
+      if (asset.creator) parts.push(`by ${asset.creator}`)
+      if (asset.license) parts.push(asset.license)
+      if (asset.modified) parts.push('modified')
+      const line = `- ${parts.join(' — ')}`
+      return asset.source || asset.licenseUrl
+        ? `${line} (${asset.source ?? asset.licenseUrl})`
+        : line
+    })
+    .join('\n')
+}
+
+/**
+ * The whole example as one document: what it is, what it pins, then its source.
+ * Versions are part of the answer -- the code is written against the `three` and
+ * drei that sit next to it, and reading it without them invites an API that
+ * moved.
+ */
+export function renderExample(example: Example) {
+  const facts = [
+    `Demo: ${example.demo}`,
+    `Source: ${example.repository}`,
+    `Scaffold: ${example.install}`,
+    example.publishedAt && `Published: ${example.publishedAt}`,
+    example.authors.length && `Authors: ${example.authors.join(', ')}`,
+    example.tags.length && `Tags: ${example.tags.join(', ')}`,
+    `Ported from: ${example.source}`,
+    `Dependencies: ${Object.entries(example.dependencies)
+      .map(([name, version]) => `${name}@${version}`)
+      .join(', ')}`,
+    example.binaries.length &&
+      `Binary files, in the repository but not below: ${example.binaries.join(', ')}`,
+    // Vendored bundles, font atlases, gltfjsx dumps. Named rather than hidden:
+    // a reader that finds an unexplained import wants to know it was skipped on
+    // size, not wonder whether the example is broken.
+    example.oversized.length &&
+      `Too large to inline, in the repository: ${example.oversized
+        .map(({ path, bytes }) => `${path} (${Math.round(bytes / 1024)} kB)`)
+        .join(', ')}`,
+  ].filter(Boolean)
+
+  const sections = [
+    `# ${example.title}`,
+    example.description.trim(),
+    facts.join('\n'),
+    example.notes?.trim(),
+    example.assets.length && `## Asset attribution\n\n${attribution(example.assets)}`,
+    ...example.files.map((file) => {
+      const language = FENCE_LANGUAGES[file.path.slice(file.path.lastIndexOf('.'))] ?? ''
+      const marks = fence(file.content)
+      return `## ${file.path}\n\n${marks}${language}\n${file.content.trimEnd()}\n${marks}`
+    }),
+  ].filter(Boolean)
+
+  return sections.join('\n\n')
+}


### PR DESCRIPTION
## Why

The server answers *"what does this API take"* and has no answer for *"how is this put together"* — which is what most r3f questions actually are. The gallery has 167 demos that answer it, and until now an agent could only reach them by cloning the repo.

## What

**`examples://index`** — the whole gallery, one line per demo:

```
aquarium · #transmission
arkanoid · Simple arkanoid implementation using cannon physics. · +cannon,zustand · #physics,game,audio
bounds-and-makedefault (Bounds and makeDefault) · #bounds
flow-shield · Interactive energy shield. · +postprocessing,leva · #shader · ~23k
```

~4.5k tokens, read once and picked from. Every part after the name is dropped when the demo does not carry it, so an entry costs what it is worth. `+` lists only what a demo uses *on top of* fiber and drei, which all of them use.

**`get_example`** — one demo in full: its source, demo URL, asset attribution, and the exact dependency versions the code is written against. That last part matters: an example is a snapshot, and a reader that takes its drei usage as current needs to see which drei it was.

## Reading, not installing

Both read the JSON catalog pmndrs/examples publishes at `/catalog/` (pmndrs/examples#178), already split per example — so a call transfers the one demo asked for rather than slicing it out of a bundle, unlike the `llms-full.txt` path the docs take.

`EXAMPLES_URL` overrides the origin. Pointing at production while changing the shape of the catalog tests the old shape.

## The size marker

The first draft of the budget advice was "read one example, not five". That is wrong for most of the gallery — the median is ~1.4k tokens, so opening the two lines that both look right costs less than the index already did, and is often the answer outright when the question is a comparison.

It was only defensible because the reader could not see what it was about to pay for. Now it can: a line carries `~23k` when the example is over 24 kB, and eight of the 167 are. **The absence of a marker is the real signal** — no marker means open it without thinking.

## Safety

`get_example` takes a name straight from the index, so it validates against the shape every published example has before that name reaches a URL. `index` is refused by name: it is legal kebab-case sitting in the same directory, and would otherwise be fetched and rendered as an example with no title and no files.

## Verification

- `pnpm exec vitest run` — 109 passing, 26 of them new (`src/utils/examples.test.ts`) plus 6 msw-backed route cases
- `pnpm run lint`, `pnpm exec tsc --noEmit`
- ran the real route against a real local build of pmndrs/examples served over HTTP: `examples://index` renders 167 lines, `get_example("caustics")` renders the expected document, `../../../etc/passwd` is refused, an unknown name reports clearly

## Order

pmndrs/examples#178 ships first. Until its catalog is deployed, `examples://index` fails with `Failed to fetch … Not Found` — loudly, not as an empty index, which is what the last test pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
