### PR TITLE
Follow the examples gallery to guessable URLs

### DIFF
--- a/.changeset/examples-guessable-urls.md
+++ b/.changeset/examples-guessable-urls.md
@@ -1,0 +1,5 @@
+---
+'@pmndrs/docs': patch
+---
+
+Follow the examples gallery to guessable URLs: an example's document is now its page URL with `.md` on the end (`/examples/caustics.md`), and the gallery index is `/llms.txt` — the same root convention every site built with this generator already publishes. `index` no longer needs reserving as a name, since it no longer collides with anything.

--- a/docs/agents/introduction.mdx
+++ b/docs/agents/introduction.mdx
@@ -66,13 +66,23 @@ An example is a snapshot, not a spec: it pins its own versions, `get_example` re
 
 > [!NOTE]
 >
-> These documents are published, not rendered here — `pmndrs/examples` writes them at build time and every example page links its own:
+> These documents are published, not rendered here — `pmndrs/examples` writes them at build time, at the page URL with an extension on the end:
+>
+> | | |
+> | --- | --- |
+> | `/examples/caustics` | the page |
+> | `/examples/caustics.md` | the same example, as `get_example` returns it |
+> | `/llms.txt` | the whole gallery, as `examples://index` returns it |
+>
+> Each page links its own, so it is found either by looking or by guessing:
 >
 > ```html
-> <link rel="alternate" type="text/markdown" href="/examples/catalog/caustics.md" />
+> <link rel="alternate" type="text/markdown" href="/examples/caustics.md" />
 > ```
 >
-> So an agent that lands on an example page, or is handed its URL, reads the same text without going through MCP at all.
+> The demos themselves — `/caustics`, which is what the READMEs' badges point at — carry the same links plus a `canonical` back to the page.
+>
+> There is no `llms-full.txt`: concatenated, the gallery is ~378k tokens, against ~50k for a documentation site. The index and one example is the whole point.
 
 > [!TIP]
 >

--- a/src/app/api/[transport]/route.test.ts
+++ b/src/app/api/[transport]/route.test.ts
@@ -65,11 +65,9 @@ const caustics = true
 const server = setupServer(
   ...llmsFullHandlers,
 
-  http.get('https://pmndrs.github.io/examples/catalog/index.md', () =>
-    HttpResponse.text(mockExampleIndex),
-  ),
+  http.get('https://pmndrs.github.io/examples/llms.txt', () => HttpResponse.text(mockExampleIndex)),
 
-  http.get('https://pmndrs.github.io/examples/catalog/caustics.md', () =>
+  http.get('https://pmndrs.github.io/examples/examples/caustics.md', () =>
     HttpResponse.text(mockExample),
   ),
 
@@ -552,7 +550,7 @@ Content with &lt;special&gt; characters &amp; symbols.
       expect(body).not.toContain('MCP server error')
     })
 
-    it.each(['../../../etc/passwd', 'index'])(
+    it.each(['../../../etc/passwd', 'Caustics'])(
       'refuses %j without reaching for a URL',
       async (name) => {
         // No msw handler exists for whatever this would resolve to, and the server
@@ -566,7 +564,7 @@ Content with &lt;special&gt; characters &amp; symbols.
 
     it('errors, rather than serving an empty gallery, when the catalog is missing', async () => {
       server.use(
-        http.get('https://pmndrs.github.io/examples/catalog/index.md', () => {
+        http.get('https://pmndrs.github.io/examples/llms.txt', () => {
           return new HttpResponse('Not Found', { status: 404 })
         }),
       )

--- a/src/app/api/[transport]/route.ts
+++ b/src/app/api/[transport]/route.ts
@@ -5,7 +5,7 @@ import { headers } from 'next/headers'
 import { revalidateTag } from 'next/cache'
 import { libs, type SUPPORTED_LIBRARY_NAMES } from '@/app/page'
 import packageJson from '@/package.json' with { type: 'json' }
-import { assertExampleName, catalogUrl } from '@/utils/examples'
+import { assertExampleName, exampleUrl, indexUrl } from '@/utils/examples'
 
 // Extract entries and library names as constants for efficiency
 // Only support libraries whose site actually publishes a /llms-full.txt dump -- see
@@ -24,19 +24,18 @@ async function baseUrl() {
 }
 
 /**
- * One document out of the examples catalog, as pmndrs/examples published it.
- * Cached and tagged like the docs dumps, except the catalog is already split per
- * example and already rendered, so a request pulls the few kB that was asked for
- * and passes it straight on.
+ * One document as pmndrs/examples published it. Cached and tagged like the docs
+ * dumps, except the gallery is already split per example and already rendered,
+ * so a request pulls the few kB that was asked for and passes it straight on.
  */
-async function fetchCatalog(file: string): Promise<string> {
-  const response = await fetch(catalogUrl(file), {
+async function fetchDocument(url: string): Promise<string> {
+  const response = await fetch(url, {
     next: { revalidate: 300, tags: ['examples-catalog'] },
   })
   // Same reason the library indexes fail loudly: a swallowed 404 reads to a
   // client as "no such example", and it will go on to invent one.
   if (!response.ok) {
-    throw new Error(`Failed to fetch ${catalogUrl(file)}: ${response.statusText}`)
+    throw new Error(`Failed to fetch ${url}: ${response.statusText}`)
   }
   return response.text()
 }
@@ -191,10 +190,10 @@ Always handle errors gracefully and consider alternative approaches when a speci
   SSE transport would need a Redis instance to relay messages, which this deployment
   does not have, so \`/api/sse\` is not usable.
 - Documentation is parsed from XML-tagged full-text dumps (\`/llms-full.txt\`)
-- Examples are passed through from the catalog the gallery publishes at
-  \`https://pmndrs.github.io/examples/catalog/\`, one already-rendered document per
-  example. They are public: every example page links its own with
-  \`rel="alternate"\`, so the same text is reachable without this server
+- Examples are passed through from what the gallery publishes: \`/llms.txt\` for the
+  index, and each example's page URL with \`.md\` on the end for the document. They
+  are public -- every example page links its own with \`rel="alternate"\` -- so the
+  same text is reachable without this server
 
 ### Security
 - CSS selector injection protection via \`.filter()\` instead of direct selectors
@@ -329,7 +328,7 @@ Always handle errors gracefully and consider alternative approaches when a speci
           contents: [
             {
               uri: 'examples://index',
-              text: await fetchCatalog('index'),
+              text: await fetchDocument(indexUrl()),
             },
           ],
         }
@@ -418,7 +417,7 @@ Always handle errors gracefully and consider alternative approaches when a speci
             content: [
               {
                 type: 'text',
-                text: await fetchCatalog(assertExampleName(name)),
+                text: await fetchDocument(exampleUrl(assertExampleName(name))),
               },
             ],
           }

--- a/src/utils/examples.test.ts
+++ b/src/utils/examples.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { assertExampleName, catalogUrl } from './examples'
+import { assertExampleName, exampleUrl, indexUrl } from './examples'
 
 /**
  * The rendering these used to cover now lives in pmndrs/examples, which
@@ -25,21 +25,29 @@ describe('assertExampleName', () => {
     expect(() => assertExampleName(name)).toThrow(/Not an example name/)
   })
 
-  it('rejects "index", which is the one name that collides with the catalog itself', () => {
-    // Legal kebab-case, same directory: it would serve the index of the whole
-    // gallery under the guise of a single example.
-    expect(() => assertExampleName('index')).toThrow(/Not an example name/)
+  it('no longer has to reserve "index"', () => {
+    // It used to collide with the catalog's own index, which sat in the same
+    // directory. The index is `/llms.txt` now, so this is just a name with no
+    // example behind it -- and 404 says that better than a special case.
+    expect(assertExampleName('index')).toBe('index')
+    expect(exampleUrl('index')).toBe('https://pmndrs.github.io/examples/examples/index.md')
   })
 })
 
-describe('catalogUrl', () => {
-  it('points at the markdown the gallery publishes, not the JSON beside it', () => {
-    expect(catalogUrl('caustics')).toBe('https://pmndrs.github.io/examples/catalog/caustics.md')
+describe('exampleUrl', () => {
+  it("is the example page's URL with .md on the end", () => {
+    expect(exampleUrl('caustics')).toBe('https://pmndrs.github.io/examples/examples/caustics.md')
   })
 
   it('follows a local build when one is given', () => {
-    expect(catalogUrl('index', 'http://localhost:3001')).toBe(
-      'http://localhost:3001/catalog/index.md',
+    expect(exampleUrl('caustics', 'http://localhost:3001')).toBe(
+      'http://localhost:3001/examples/caustics.md',
     )
+  })
+})
+
+describe('indexUrl', () => {
+  it('is the root convention, not a page sibling', () => {
+    expect(indexUrl()).toBe('https://pmndrs.github.io/examples/llms.txt')
   })
 })

--- a/src/utils/examples.ts
+++ b/src/utils/examples.ts
@@ -2,11 +2,10 @@
  * The examples gallery, as served by this MCP server.
  *
  * There is very little here on purpose. pmndrs/examples publishes the documents
- * an agent reads -- `/catalog/index.md` and `/catalog/<name>.md` -- already
- * rendered, because they are published for the open web too: every example page
- * points at its markdown with `rel="alternate"`, and a static host cannot render
- * on demand. So this server hands them on verbatim rather than building a second
- * rendering that would drift from the first.
+ * an agent reads, already rendered, because they are published for the open web
+ * too: every example page points at its markdown with `rel="alternate"`, and a
+ * static host cannot render on demand. So this server hands them on verbatim
+ * rather than building a second rendering that would drift from the first.
  *
  * That leaves one job worth doing here: making sure a name from a model reaches
  * a URL only if it is the shape a published example has.
@@ -14,7 +13,7 @@
 
 /**
  * Where the gallery lives. Overridable so the MCP server can be developed
- * against a local `pnpm build` of pmndrs/examples -- the catalog only exists
+ * against a local `pnpm build` of pmndrs/examples -- the documents only exist
  * once that repo has built.
  */
 export const EXAMPLES_URL = process.env.EXAMPLES_URL || 'https://pmndrs.github.io/examples'
@@ -23,18 +22,25 @@ export const EXAMPLES_URL = process.env.EXAMPLES_URL || 'https://pmndrs.github.i
 const EXAMPLE_NAME = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
 
 /**
- * `index` is legal kebab-case and sits in the same directory, so it would serve
- * the index of the whole gallery under the guise of one example.
+ * An example's document is its page URL with `.md` on the end, so it can be
+ * guessed rather than discovered -- `/examples/caustics` and
+ * `/examples/caustics.md` are the same example, for two kinds of reader.
  */
-const RESERVED_NAME = 'index'
+export function exampleUrl(name: string, base = EXAMPLES_URL) {
+  return `${base}/examples/${name}.md`
+}
 
-export function catalogUrl(file: string, base = EXAMPLES_URL) {
-  return `${base}/catalog/${file}.md`
+/**
+ * The gallery index. Not `/examples.md`, because appending an extension only
+ * works for a page that has a filename: a reader who tries it on the gallery
+ * root asks for `/.md`. `llms.txt` is the root convention for this, and every
+ * site built with this generator already publishes one.
+ */
+export function indexUrl(base = EXAMPLES_URL) {
+  return `${base}/llms.txt`
 }
 
 export function assertExampleName(name: string) {
-  if (!EXAMPLE_NAME.test(name) || name === RESERVED_NAME) {
-    throw new Error(`Not an example name: ${name}`)
-  }
+  if (!EXAMPLE_NAME.test(name)) throw new Error(`Not an example name: ${name}`)
   return name
 }


### PR DESCRIPTION
Follows pmndrs/examples#180, which moves the published documents to URLs a reader can guess instead of having to discover.

## What changes

| | before | after |
| --- | --- | --- |
| one example | `/catalog/caustics.md` | `/examples/caustics.md` — the page URL with `.md` on the end |
| the gallery | `/catalog/index.md` | `/llms.txt` — the root convention every site built with this generator already publishes |

`catalogUrl` splits into `exampleUrl` and `indexUrl`, because the two no longer share a shape — and that asymmetry is the point. Appending an extension only works for a page that has a filename; a reader who tries it on the gallery root asks for `/.md`.

## `index` no longer needs reserving

It was refused by name because `/catalog/index.md` was the gallery index sitting in the same directory as every example, so `get_example("index")` would have served the whole catalogue dressed as one demo.

There is no such file now. `index` is just a name with no example behind it, and a 404 says that better than a special case did. The test that pinned the reservation now pins its absence.

## Docs

The agents page gets the URL table, the note that each page links its own, and a line on the demos themselves — `/caustics`, which is what the READMEs' badges point at — now carrying the same links plus a `canonical` back to the page.

It also records why there is no `llms-full.txt`: concatenated, the gallery is ~378k tokens against ~50k for a documentation site. The index plus one example is the whole design, not a limitation.

## Verification

- `pnpm exec vitest run` — 95 passing; `pnpm run lint`, `pnpm exec tsc --noEmit`
- ran the real route against a real local build of pmndrs/examples#180 served over HTTP: the index comes from `/llms.txt` and returns 167 lines, `get_example("spotlight-shadows")` comes from `/examples/spotlight-shadows.md` and returns the document with its attribution, an unknown name 404s naming `examples/no-such-demo.md`

## Order

pmndrs/examples#180 ships first. It keeps writing the old `/catalog/` paths for one release precisely so this one can follow without a gap — so there is no window where either server is asking for something that does not exist. A follow-up there deletes them once this is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
