### PR TITLE
fix: insert the Sandpack stylesheet once, not once per chunk

### DIFF
--- a/.changeset/sandpack-css-once.md
+++ b/.changeset/sandpack-css-once.md
@@ -1,0 +1,14 @@
+---
+'@pmndrs/docs': patch
+---
+
+Stop repeating the Sandpack stylesheet on every streamed chunk
+
+`useServerInsertedHTML` is called back on each flush of the response and expects what is new
+since the last one, but the callback returned the whole Sandpack stylesheet every time. Pages
+carried one full copy per chunk — 145 identical copies of the same 8.9 kB on the worst of
+them, three quarters of the page weight.
+
+Which pages were hit moved from build to build: the stylesheet is a module-level singleton,
+so it depended on whether a page using Sandpack had been rendered earlier in the same build
+process. Pages with no Sandpack of their own paid for their neighbours.

--- a/src/app/sandpack-styles.tsx
+++ b/src/app/sandpack-styles.tsx
@@ -4,12 +4,23 @@
 
 import { getSandpackCssText } from '@codesandbox/sandpack-react'
 import { useServerInsertedHTML } from 'next/navigation'
+import { useRef } from 'react'
 
 /**
  * Ensures CSSinJS styles are loaded server side.
  */
 export const SandpackCSS = () => {
+  // Next calls this back on every flush of the streamed response, expecting whatever is new
+  // since the last one. Sandpack's stylesheet is built when the module loads and never grows
+  // after that, so everything it has to give is already there on the first call — and every
+  // later call would repeat all of it. A page streamed in 141 chunks carried 145 identical
+  // copies of the same 8.9 kB, three quarters of its weight.
+  const inserted = useRef(false)
+
   useServerInsertedHTML(() => {
+    if (inserted.current) return null
+    inserted.current = true
+
     return <style dangerouslySetInnerHTML={{ __html: getSandpackCssText() }} id="sandpack" />
   })
   return null


### PR DESCRIPTION
`useServerInsertedHTML` calls its callback back on **every flush** of the streamed response, and expects whatever is new since the last one — that is how the styled-components and styled-jsx adapters use it, reading their sheet and clearing it.

`SandpackCSS` returned the whole stylesheet each time instead. A page streamed in *n* chunks therefore carried *n* full copies of it.

```tsx
useServerInsertedHTML(() => {
  return <style dangerouslySetInnerHTML={{ __html: getSandpackCssText() }} id="sandpack" />
})
```

## Measured

| page | `<style id="sandpack">` | bytes in them | after |
|---|---|---|---|
| `authoring/contributors.html` | 145 | 1256 kB | 1 tag, 8 kB |
| `authoring/code.html` | 153 | 417 kB | 1 tag, 2 kB |
| `index.html` | 38 | 329 kB | 1 tag, 8 kB |

`contributors.html` goes from **1772 kB to 513 kB**, and the whole site from **78 MB to 66 MB**. Every page's reduction matches that of its own style tags to within ~10 kB, so it is all attributable to this.

## Why pages with no Sandpack were affected

The stylesheet is a module-level singleton. Any page using Sandpack rendered earlier in the same build process fills it for every page that follows — `contributors.mdx` uses `<Contributors>` and `<Intro>`, nothing else. That is also why the worst-hit pages moved from one build to the next, which made this look like build nondeterminism until the style tags were counted.

## Why emitting once cannot lose anything

The sheet is built when the module loads and never grows afterwards. All 145 copies on `contributors.html` were byte-identical (1 distinct value), so there is no later addition to miss. If that ever changed, the callback would need to emit the delta rather than guard on a flag.

The original code is the one from [Sandpack's own app-dir SSR guide](https://sandpack.codesandbox.io/docs/guides/ssr#nextjs-app-dir) — correct as long as there is a single flush, which stops being true as soon as the page streams.
