### PR TITLE
Open the Release PR as an App, so its checks start on their own

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,32 @@ jobs:
       # ███████ ███████    ██     ██████  ██
       #
 
+      # The Release PR is pushed and opened by this App, not by `github-actions[bot]`. Since
+      # June 2026 GitHub holds every `pull_request` run on a bot-authored PR at
+      # `action_required` when the default token is what touched it — one manual "Approve and
+      # run" per push to the Release PR, so on every merge to main. An App installation token
+      # is a trusted identity, so those runs start on their own.
+      #
+      # Minted before the checkout rather than beside the step that needs it: `actions/checkout`
+      # persists its own token in the remote URL, and that is the credential `changesets/action`
+      # pushes the branch with. Pass it here or the push carries `github-actions[bot]` whatever
+      # the API calls use.
+      #
+      # `continue-on-error` so this degrades instead of breaking: wherever the App is not
+      # installed, every use below falls back to the default token.
+      - name: Mint an App token
+        id: app-token
+        if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        continue-on-error: true
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token || github.token }}
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v6
         with:
@@ -65,7 +88,7 @@ jobs:
           publish: pnpm run release
           createGithubReleases: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
 
       - name: Check version bump
         id: check


### PR DESCRIPTION
Every push to the Release PR currently parks its checks at **"1 workflow awaiting approval"**, so merging to `main` costs a manual *Approve and run*. Since June 2026 GitHub holds `pull_request` runs on bot-authored PRs whenever the default token is what touched them.

An App installation token is a trusted identity, so those runs start on their own. Same fix as `abernier/material-theme-builder`.

The token is minted **before** the checkout rather than beside the step that needs it: `actions/checkout` persists its own token in the remote URL, and that is the credential `changesets/action` pushes the branch with. Passing it only to the action would leave the push carrying `github-actions[bot]`.

## Safe to merge before the App exists

`continue-on-error: true` on the mint step, and every use falls back to the default token:

```yaml
token: ${{ steps.app-token.outputs.token || github.token }}
GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
```

So until the App is set up this is a no-op — today's behaviour, manual approval included.

## What makes it take effect

1. A GitHub App installed on `pmndrs/docs`, with **Contents: read & write** and **Pull requests: read & write**
2. Repository **variable** `RELEASE_APP_ID`
3. Repository **secret** `RELEASE_APP_PRIVATE_KEY`

Note that `pmndrs` is an organisation: installing an App there may need an org owner even though repository admin is enough for the variable and the secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfCBpbazo3fr1n2EUXNyh5
