### PR TITLE
Pin the documented npx invocations to @latest

### DIFF
--- a/.changeset/npx-latest.md
+++ b/.changeset/npx-latest.md
@@ -1,0 +1,7 @@
+---
+'@pmndrs/docs': patch
+---
+
+Document `npx @pmndrs/docs@latest` rather than `npx @pmndrs/docs`. Without a version, `npx`
+reuses whatever it already has in its cache, so a copy from weeks ago wins silently and the
+command appears not to have changed.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 # Usage
 
 ```sh
-$ cat foo.mdx | npx @pmndrs/docs build               # one HTML fragment, on stdout
-$ npx @pmndrs/docs build docs out                    # one .html per .mdx, assets alongside
-$ npx @pmndrs/docs build docs out --format website   # the whole website, statically exported
+$ cat foo.mdx | npx @pmndrs/docs@latest build               # one HTML fragment, on stdout
+$ npx @pmndrs/docs@latest build docs out                    # one .html per .mdx, assets alongside
+$ npx @pmndrs/docs@latest build docs out --format website   # the whole website, statically exported
 ```
 
 `--format fragment` (the default) needs nothing but node — no `next build`, no bundler. A

--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -223,7 +223,7 @@ $ (
   export ICON=🇨🇭
   export GITHUB=https://github.com/pmndrs/react-three-fiber
 
-  npx -y @pmndrs/docs build docs docs/out --format website
+  npx -y @pmndrs/docs@latest build docs docs/out --format website
 
   kill $(lsof -ti:"$_PORT")
   npx serve docs -p $_PORT --no-port-switching --no-clipboard &
@@ -236,7 +236,7 @@ $ (
 
 Then go to: http://localhost:3000
 
-Every option above has a flag too — `npx @pmndrs/docs build --help` lists them.
+Every option above has a flag too — `npx @pmndrs/docs@latest build --help` lists them.
 
 ## Agents
 


### PR DESCRIPTION
Without a version specifier, `npx` reuses whatever it already has in its cache — a copy from weeks ago wins silently, and the command looks like it has not changed.

`preview.sh` (`@$VERSION`, defaulting to `latest`) and `build.yml` (`@${{ inputs.version }}`) already name one, so only the prose moves: README and the getting-started page.

Patch changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfCBpbazo3fr1n2EUXNyh5