### PR TITLE
refactor: extract the `libs` registry out of `src/app/page.tsx`

### DIFF
--- a/.changeset/libs-registry.md
+++ b/.changeset/libs-registry.md
@@ -1,0 +1,7 @@
+---
+'@pmndrs/docs': patch
+---
+
+Move the `libs` registry out of `src/app/page.tsx` and into `src/libs.ts`, a module with no Next imports.
+
+The page keeps the icon imports and pairs them with the entries it renders; the MCP route reads the plain module instead of importing a page backwards. Anything that is not a browser — a script, a test, the CLI — can now read the registry.

--- a/src/app/api/[transport]/route.test.ts
+++ b/src/app/api/[transport]/route.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll, afterEach, vi, beforeEach } from 'vitest'
 import { setupServer } from 'msw/node'
 import { http, HttpResponse } from 'msw'
-import { libs } from '@/app/page'
+import { libs } from '@/libs'
 
 // Mock Next.js headers before importing the route
 vi.mock('next/headers', () => ({
@@ -191,7 +191,7 @@ describe('MCP Route Handler', () => {
 
   describe('Library Filtering', () => {
     it('should expose exactly the libraries flagged with llms_full', async () => {
-      const { libs } = await import('@/app/page')
+      const { libs } = await import('@/libs')
 
       const exposed = Object.entries(libs)
         .filter(([, lib]) => 'llms_full' in lib && lib.llms_full)
@@ -201,7 +201,7 @@ describe('MCP Route Handler', () => {
     })
 
     it('should exclude pmndrs.github.io libraries that publish no llms-full.txt', async () => {
-      const { libs } = await import('@/app/page')
+      const { libs } = await import('@/libs')
 
       // Regression: these are hosted on pmndrs.github.io but are not built with this
       // generator, so `${docs_url}/llms-full.txt` 404s. Selecting on the host alone
@@ -222,7 +222,7 @@ describe('MCP Route Handler', () => {
     })
 
     it('should exclude libraries documented outside pmndrs', async () => {
-      const { libs } = await import('@/app/page')
+      const { libs } = await import('@/libs')
 
       for (const libname of ['react-spring', 'jotai', 'valtio'] as const) {
         expect('llms_full' in libs[libname] && libs[libname].llms_full).toBeFalsy()

--- a/src/app/api/[transport]/route.ts
+++ b/src/app/api/[transport]/route.ts
@@ -3,13 +3,13 @@ import * as cheerio from 'cheerio'
 import { z } from 'zod'
 import { headers } from 'next/headers'
 import { revalidateTag } from 'next/cache'
-import { libs, type SUPPORTED_LIBRARY_NAMES } from '@/app/page'
+import { libs, type SUPPORTED_LIBRARY_NAMES } from '@/libs'
 import packageJson from '@/package.json' with { type: 'json' }
 import { assertExampleName, exampleUrl, indexUrl } from '@/utils/examples'
 
 // Extract entries and library names as constants for efficiency
 // Only support libraries whose site actually publishes a /llms-full.txt dump -- see
-// the `llms_full` flag in `src/app/page.tsx`. Being hosted on pmndrs.github.io is not
+// the `llms_full` flag in `src/libs.ts`. Being hosted on pmndrs.github.io is not
 // enough: most of those sites are not built with this generator and 404 on that file,
 // which used to leave their index resource silently empty.
 const libsEntries = Object.entries(libs).filter(([, lib]) => 'llms_full' in lib && lib.llms_full)

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,148 +10,24 @@ import Icon from '@/components/Icon'
 import { Code } from '@/components/mdx/Code/Code'
 import { Gha } from '@/components/mdx/Gha/Gha'
 import { Badge } from '@/components/ui/badge'
+import { libs } from '@/libs'
 import { svg } from '@/utils/icon'
 import { Metadata } from 'next'
-import Image from 'next/image'
+import Image, { type StaticImageData } from 'next/image'
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
 
-export interface Library {
-  title: string
-  docs_url: string
-  github: string
-  description: string
-  // Optional banner image
-  image?: string
-  // Optional project icon
-  icon?: string
-  iconWidth?: number
-  iconHeight?: number
-  // Whether `${docs_url}/llms-full.txt` exists, i.e. the site is built with this
-  // generator. Only these libraries can be served over MCP -- see
-  // `src/app/api/[transport]/route.ts`. Flip it on once a site ships its dump.
-  llms_full?: boolean
+/** The icons, kept here because they are assets: `@/libs` stays readable outside Next. */
+const icons: Partial<Record<keyof typeof libs, StaticImageData>> = {
+  'react-three-fiber': r3fIcon,
+  'react-spring': reactSpringIcon,
+  drei: dreiIcon,
+  zustand: zustandIcon,
+  jotai: jotaiIcon,
+  'react-postprocessing': ppIcon,
+  uikit: uiKitIcon,
+  docs: docsIcon,
 }
-
-export const libs = {
-  'react-three-fiber': {
-    title: 'React Three Fiber',
-    docs_url: 'https://pmndrs.github.io/react-three-fiber',
-    github: 'https://github.com/pmndrs/react-three-fiber',
-    description: 'React-three-fiber is a React renderer for three.js',
-    llms_full: true,
-    icon: r3fIcon.src,
-    iconWidth: r3fIcon.width,
-    iconHeight: r3fIcon.height,
-  },
-  'react-spring': {
-    title: 'React Spring',
-    docs_url: 'https://react-spring.io',
-    github: 'https://github.com/pmndrs/react-spring',
-    description: 'Bring your components to life with simple spring animation primitives for React',
-    icon: reactSpringIcon.src,
-    iconWidth: reactSpringIcon.width,
-    iconHeight: reactSpringIcon.height,
-  },
-  drei: {
-    title: 'Drei',
-    docs_url: 'https://pmndrs.github.io/drei',
-    github: 'https://github.com/pmndrs/drei',
-    description:
-      'Drei is a growing collection of useful helpers and abstractions for react-three-fiber',
-    llms_full: true,
-    icon: dreiIcon.src,
-    iconWidth: dreiIcon.width,
-    iconHeight: dreiIcon.height,
-  },
-  zustand: {
-    title: 'Zustand',
-    docs_url: 'https://pmndrs.github.io/zustand',
-    github: 'https://github.com/pmndrs/zustand',
-    description:
-      'Zustand is a small, fast and scalable bearbones state-management solution, it has a comfy api based on hooks',
-    llms_full: true,
-    icon: zustandIcon.src,
-    iconWidth: zustandIcon.width,
-    iconHeight: zustandIcon.height,
-  },
-  jotai: {
-    title: 'Jotai',
-    docs_url: 'https://jotai.org/docs/introduction',
-    github: 'https://github.com/pmndrs/jotai',
-    description: 'Jotai is a primitive and flexible state management library for React',
-    icon: jotaiIcon.src,
-    iconWidth: jotaiIcon.width,
-    iconHeight: jotaiIcon.height,
-  },
-  valtio: {
-    title: 'Valtio',
-    docs_url: 'https://valtio.pmnd.rs',
-    github: 'https://github.com/pmndrs/valtio',
-    description: 'Valtio makes proxy-state simple for React and Vanilla',
-  },
-  a11y: {
-    title: 'A11y',
-    docs_url: 'https://pmndrs.github.io/react-three-a11y',
-    github: 'https://github.com/pmndrs/react-three-a11y',
-    description:
-      '@react-three/a11y brings accessibility to webGL with easy-to-use react-three-fiber components',
-  },
-  'react-postprocessing': {
-    title: 'React Postprocessing',
-    docs_url: 'https://pmndrs.github.io/react-postprocessing',
-    github: 'https://github.com/pmndrs/react-postprocessing',
-    description: 'React Postprocessing is a postprocessing wrapper for @react-three/fiber',
-    icon: ppIcon.src,
-    iconWidth: ppIcon.width,
-    iconHeight: ppIcon.height,
-  },
-  uikit: {
-    title: 'uikit',
-    docs_url: 'https://pmndrs.github.io/uikit/docs',
-    github: 'https://github.com/pmndrs/uikit',
-    description: 'uikit brings user interfaces to @react-three/fiber',
-    icon: uiKitIcon.src,
-    iconWidth: uiKitIcon.width,
-    iconHeight: uiKitIcon.height,
-  },
-  xr: {
-    title: 'xr',
-    docs_url: 'https://pmndrs.github.io/xr/docs',
-    github: 'https://github.com/pmndrs/xr',
-    description: 'VR/AR for @react-three/fiber',
-  },
-  docs: {
-    title: 'Docs',
-    docs_url: '/getting-started/introduction',
-    github: 'https://github.com/pmndrs/docs',
-    description: 'Documentation generator for `pmndrs/*`',
-    llms_full: true,
-    icon: docsIcon.src,
-    iconWidth: docsIcon.width,
-    iconHeight: docsIcon.height,
-  },
-  prai: {
-    title: 'prai',
-    docs_url: 'https://pmndrs.github.io/prai',
-    github: 'https://github.com/pmndrs/prai',
-    description: 'JS Framework for building step-by-step LLM instructions`',
-  },
-  viverse: {
-    title: 'viverse',
-    docs_url: 'https://pmndrs.github.io/viverse',
-    github: 'https://github.com/pmndrs/viverse',
-    description: 'Toolkit for building Three.js and React Three Fiber Apps for VIVERSE and beyond.',
-  },
-  leva: {
-    title: 'leva',
-    docs_url: 'https://pmndrs.github.io/leva',
-    github: 'https://github.com/pmndrs/leva',
-    description: 'React-first components GUI',
-  },
-} as const satisfies Record<string, Library>
-
-export type SUPPORTED_LIBRARY_NAMES = keyof typeof libs
 
 const title = 'Poimandres documentation'
 const description = `Index of documentation for pmndrs/* libraries`
@@ -250,69 +126,71 @@ export default function Page() {
           </section>
 
           <main className="max-w-8xl mt-8 grid w-full grid-cols-1 gap-8 lg:mt-10 lg:grid-cols-2 lg:gap-12 2xl:grid-cols-3">
-            {Object.entries(libs).map(([id, data]) => (
-              <div
-                key={id}
-                className="group/card bg-surface-container relative overflow-hidden rounded-md border border-outline-variant font-normal"
-              >
-                <div className="relative z-10 flex h-full flex-col justify-between">
-                  <div className="flex items-start justify-between gap-6 px-6 py-6">
-                    <div className="max-w-md">
-                      <div className="flex items-center gap-2">
-                        <div className="text-lg font-bold">{data.title}</div>
-                        {'llms_full' in data && data.llms_full && (
-                          <Badge
-                            variant="secondary"
-                            title={`Reachable from an MCP client as lib="${id}"`}
-                          >
-                            MCP
-                          </Badge>
-                        )}
+            {Object.entries(libs).map(([id, data]) => {
+              const icon = icons[id as keyof typeof libs]
+
+              return (
+                <div
+                  key={id}
+                  className="group/card bg-surface-container relative overflow-hidden rounded-md border border-outline-variant font-normal"
+                >
+                  <div className="relative z-10 flex h-full flex-col justify-between">
+                    <div className="flex items-start justify-between gap-6 px-6 py-6">
+                      <div className="max-w-md">
+                        <div className="flex items-center gap-2">
+                          <div className="text-lg font-bold">{data.title}</div>
+                          {'llms_full' in data && data.llms_full && (
+                            <Badge
+                              variant="secondary"
+                              title={`Reachable from an MCP client as lib="${id}"`}
+                            >
+                              MCP
+                            </Badge>
+                          )}
+                        </div>
+                        <div className="grow text-sm leading-relaxed! text-on-surface-variant/50">
+                          {data.description}
+                        </div>
                       </div>
-                      <div className="grow text-sm leading-relaxed! text-on-surface-variant/50">
-                        {data.description}
-                      </div>
+                      {icon && (
+                        <a
+                          href={data.github}
+                          target="_blank"
+                          rel="noopener"
+                          className="relative block h-20 w-20 shrink-0"
+                        >
+                          <Image
+                            src={icon}
+                            className="absolute inset-0 h-full w-full object-contain grayscale transition group-hover/card:grayscale-0"
+                            alt={data.title}
+                            aria-hidden
+                          />
+                        </a>
+                      )}
                     </div>
-                    {'icon' in data && data.icon && (
+                    <div className="flex w-full divide-x divide-outline-variant border-t border-outline-variant text-sm">
+                      <Link
+                        href={data.docs_url}
+                        className="bg-surface-container inline-flex flex-1 items-center space-x-2 px-6 py-4 transition-colors"
+                      >
+                        <Icon icon="docs" />
+                        <span className="sm:hidden">Docs</span>
+                        <span className="hidden sm:inline">Documentation</span>
+                      </Link>
                       <a
                         href={data.github}
                         target="_blank"
-                        rel="noopener"
-                        className="relative block h-20 w-20 shrink-0"
+                        rel="noopener noreferrer"
+                        className="bg-surface-container inline-flex flex-1 items-center space-x-2 px-6 py-4 transition-colors"
                       >
-                        <Image
-                          src={data.icon}
-                          className="absolute inset-0 h-full w-full object-contain grayscale transition group-hover/card:grayscale-0"
-                          alt={data.title}
-                          aria-hidden
-                          width={data.iconWidth}
-                          height={data.iconHeight}
-                        />
+                        <Icon icon="github" />
+                        <span>GitHub</span>
                       </a>
-                    )}
-                  </div>
-                  <div className="flex w-full divide-x divide-outline-variant border-t border-outline-variant text-sm">
-                    <Link
-                      href={data.docs_url}
-                      className="bg-surface-container inline-flex flex-1 items-center space-x-2 px-6 py-4 transition-colors"
-                    >
-                      <Icon icon="docs" />
-                      <span className="sm:hidden">Docs</span>
-                      <span className="hidden sm:inline">Documentation</span>
-                    </Link>
-                    <a
-                      href={data.github}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="bg-surface-container inline-flex flex-1 items-center space-x-2 px-6 py-4 transition-colors"
-                    >
-                      <Icon icon="github" />
-                      <span>GitHub</span>
-                    </a>
+                    </div>
                   </div>
                 </div>
-              </div>
-            ))}
+              )
+            })}
           </main>
         </div>
       </div>

--- a/src/libs.ts
+++ b/src/libs.ts
@@ -1,0 +1,116 @@
+/**
+ * The pmndrs libraries this site indexes.
+ *
+ * Deliberately free of Next imports -- the icons live in `src/app/page.tsx`, next to the
+ * `<Image>` that renders them. Everything that is not a browser reads this module: the MCP
+ * route, the `browse` CLI, a script, a test.
+ */
+
+export interface Library {
+  title: string
+  docs_url: string
+  github: string
+  description: string
+  // Optional banner image
+  image?: string
+  // Whether `${docs_url}/llms-full.txt` exists, i.e. the site is built with this
+  // generator. Only these libraries can be served over MCP -- see
+  // `src/app/api/[transport]/route.ts`. Flip it on once a site ships its dump.
+  llms_full?: boolean
+}
+
+export const libs = {
+  'react-three-fiber': {
+    title: 'React Three Fiber',
+    docs_url: 'https://pmndrs.github.io/react-three-fiber',
+    github: 'https://github.com/pmndrs/react-three-fiber',
+    description: 'React-three-fiber is a React renderer for three.js',
+    llms_full: true,
+  },
+  'react-spring': {
+    title: 'React Spring',
+    docs_url: 'https://react-spring.io',
+    github: 'https://github.com/pmndrs/react-spring',
+    description: 'Bring your components to life with simple spring animation primitives for React',
+  },
+  drei: {
+    title: 'Drei',
+    docs_url: 'https://pmndrs.github.io/drei',
+    github: 'https://github.com/pmndrs/drei',
+    description:
+      'Drei is a growing collection of useful helpers and abstractions for react-three-fiber',
+    llms_full: true,
+  },
+  zustand: {
+    title: 'Zustand',
+    docs_url: 'https://pmndrs.github.io/zustand',
+    github: 'https://github.com/pmndrs/zustand',
+    description:
+      'Zustand is a small, fast and scalable bearbones state-management solution, it has a comfy api based on hooks',
+    llms_full: true,
+  },
+  jotai: {
+    title: 'Jotai',
+    docs_url: 'https://jotai.org/docs/introduction',
+    github: 'https://github.com/pmndrs/jotai',
+    description: 'Jotai is a primitive and flexible state management library for React',
+  },
+  valtio: {
+    title: 'Valtio',
+    docs_url: 'https://valtio.pmnd.rs',
+    github: 'https://github.com/pmndrs/valtio',
+    description: 'Valtio makes proxy-state simple for React and Vanilla',
+  },
+  a11y: {
+    title: 'A11y',
+    docs_url: 'https://pmndrs.github.io/react-three-a11y',
+    github: 'https://github.com/pmndrs/react-three-a11y',
+    description:
+      '@react-three/a11y brings accessibility to webGL with easy-to-use react-three-fiber components',
+  },
+  'react-postprocessing': {
+    title: 'React Postprocessing',
+    docs_url: 'https://pmndrs.github.io/react-postprocessing',
+    github: 'https://github.com/pmndrs/react-postprocessing',
+    description: 'React Postprocessing is a postprocessing wrapper for @react-three/fiber',
+  },
+  uikit: {
+    title: 'uikit',
+    docs_url: 'https://pmndrs.github.io/uikit/docs',
+    github: 'https://github.com/pmndrs/uikit',
+    description: 'uikit brings user interfaces to @react-three/fiber',
+  },
+  xr: {
+    title: 'xr',
+    docs_url: 'https://pmndrs.github.io/xr/docs',
+    github: 'https://github.com/pmndrs/xr',
+    description: 'VR/AR for @react-three/fiber',
+  },
+  docs: {
+    title: 'Docs',
+    docs_url: '/getting-started/introduction',
+    github: 'https://github.com/pmndrs/docs',
+    description: 'Documentation generator for `pmndrs/*`',
+    llms_full: true,
+  },
+  prai: {
+    title: 'prai',
+    docs_url: 'https://pmndrs.github.io/prai',
+    github: 'https://github.com/pmndrs/prai',
+    description: 'JS Framework for building step-by-step LLM instructions`',
+  },
+  viverse: {
+    title: 'viverse',
+    docs_url: 'https://pmndrs.github.io/viverse',
+    github: 'https://github.com/pmndrs/viverse',
+    description: 'Toolkit for building Three.js and React Three Fiber Apps for VIVERSE and beyond.',
+  },
+  leva: {
+    title: 'leva',
+    docs_url: 'https://pmndrs.github.io/leva',
+    github: 'https://github.com/pmndrs/leva',
+    description: 'React-first components GUI',
+  },
+} as const satisfies Record<string, Library>
+
+export type SUPPORTED_LIBRARY_NAMES = keyof typeof libs


### PR DESCRIPTION
Closes #580.

`libs` — the list of pmndrs libraries with `docs_url`, `github`, `description` and `llms_full` — lived in `src/app/page.tsx`, a module that also imports `@/assets/*.svg`, `next/image` and `next/navigation`. Nothing outside the Next build could read it:

- `src/app/api/[transport]/route.ts` (MCP) got away with `import { libs } from '@/app/page'` only because it runs inside Next — a route importing a page backwards.
- The `browse` prototype (#579) had to duplicate the registry outright to read it from a plain node process.

`src/libs.ts` now holds the data and its `Library` type, with no Next import.

The icons leave the registry along the way — `icon`, `iconWidth`, `iconHeight` were the flattened remains of a static import, i.e. assets rather than data. `page.tsx` keeps the imports and pairs them with the entries by key at the point it renders them, which also lets `<Image>` infer the intrinsic size itself.

No compatibility re-export from `@/app/page`: the two consumers moved with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YUbKJpnDkFoYEiFDPJCwng