### PR TITLE
Stop publishing the API route

### DIFF
--- a/.changeset/drop-api-route.md
+++ b/.changeset/drop-api-route.md
@@ -1,0 +1,12 @@
+---
+'@pmndrs/docs': patch
+---
+
+Stop publishing `src/app/api`. A Route Handler cannot be statically exported, and the CLI
+already leaves it behind when it copies the app, so it only ever travelled as dead weight —
+37 kB of it, once its test is counted.
+
+One test file still ships, `src/app/[...slug]/page.test.ts`. Nothing under a bracketed
+directory can be excluded through `files` under `pnpm`, whatever the pattern: `npm pack` honours
+`!**/*.test.*` there, `pnpm pack` does not, and neither a directory negation nor an escaped
+bracket reaches it.

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "postcss.config.mjs",
     "tsconfig.json",
     "!src/stories",
+    "!src/app/api",
     "!**/*.test.*",
     "!**/*.stories.*"
   ]


### PR DESCRIPTION
The published tarball carried `src/app/api` — a Route Handler that a static export cannot use, and that `buildWebsite` already drops when it copies the app. 37 kB of dead weight with its test.

```
4.0.1 as published   155 files
with this change     153 files, src/app/api gone
```

## The part that does not get fixed

`src/app/[...slug]/page.test.ts` still ships, and no pattern removes it. **Nothing under a bracketed directory can be excluded through `files` under pnpm.**

Reproduced on four files — `files: ["src", "!**/*.test.*"]`:

```
src/plain/keep.ts        src/plain/drop.test.ts
src/[x]/keep.ts          src/[x]/drop.test.ts
```

```
npm pack   → src/plain/keep.ts  src/[x]/keep.ts              both tests excluded
pnpm pack  → src/plain/keep.ts  src/[x]/keep.ts  src/[x]/drop.test.ts
```

Every alternative was tried and every one leaks: `!src/*/*.test.*`, `!src/[[]x]/*.test.*`, `!**/drop.test.ts`, `!src/**/drop.test.ts`, and the directory negations `!src/[x]` and `!src/[[]x]`. A negation on a *bracket-free* directory does work — `!src/plain` removes it — which is exactly why `!src/app/api` is the fix that lands here.

`changeset publish` packs with pnpm when it detects pnpm, so this is the tool that actually builds our releases. Worth an upstream issue; 1.1 kB is not worth contorting the layout for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfCBpbazo3fr1n2EUXNyh5
