### PR TITLE
fix: flag react-postprocessing and a11y as publishing a llms-full.txt

### DIFF
--- a/.changeset/tidy-moons-report.md
+++ b/.changeset/tidy-moons-report.md
@@ -1,0 +1,7 @@
+---
+'@pmndrs/docs': patch
+---
+
+Read `react-postprocessing` and `a11y` in `browse` and over MCP. Both sites publish a
+`llms-full.txt` now — react-postprocessing has for a while, a11y since its build moved to v4 —
+so the flag was simply behind the world.

--- a/src/app/api/[transport]/route.test.ts
+++ b/src/app/api/[transport]/route.test.ts
@@ -197,7 +197,14 @@ describe('MCP Route Handler', () => {
         .filter(([, lib]) => 'llms_full' in lib && lib.llms_full)
         .map(([libname]) => libname)
 
-      expect(exposed).toEqual(['react-three-fiber', 'drei', 'zustand', 'docs'])
+      expect(exposed).toEqual([
+        'react-three-fiber',
+        'drei',
+        'zustand',
+        'a11y',
+        'react-postprocessing',
+        'docs',
+      ])
     })
 
     it('should exclude pmndrs.github.io libraries that publish no llms-full.txt', async () => {
@@ -206,15 +213,7 @@ describe('MCP Route Handler', () => {
       // Regression: these are hosted on pmndrs.github.io but are not built with this
       // generator, so `${docs_url}/llms-full.txt` 404s. Selecting on the host alone
       // used to expose them with a silently empty index.
-      for (const libname of [
-        'a11y',
-        'react-postprocessing',
-        'uikit',
-        'xr',
-        'prai',
-        'viverse',
-        'leva',
-      ] as const) {
+      for (const libname of ['uikit', 'xr', 'prai', 'viverse', 'leva'] as const) {
         const lib = libs[libname]
         expect(lib.docs_url).toContain('pmndrs.github.io')
         expect('llms_full' in lib && lib.llms_full).toBeFalsy()

--- a/src/libs.ts
+++ b/src/libs.ts
@@ -67,12 +67,14 @@ export const libs = {
     github: 'https://github.com/pmndrs/react-three-a11y',
     description:
       '@react-three/a11y brings accessibility to webGL with easy-to-use react-three-fiber components',
+    llms_full: true,
   },
   'react-postprocessing': {
     title: 'React Postprocessing',
     docs_url: 'https://pmndrs.github.io/react-postprocessing',
     github: 'https://github.com/pmndrs/react-postprocessing',
     description: 'React Postprocessing is a postprocessing wrapper for @react-three/fiber',
+    llms_full: true,
   },
   uikit: {
     title: 'uikit',


### PR DESCRIPTION
`llms_full` in `src/libs.ts` is the whole filter for what `browse`, `search` and the MCP server can read — a site not built with this generator 404s on `/llms-full.txt`. It is hand-maintained, so it drifts.

Probing all 13 entries turned up two that publish the dump today but were still flagged off:

| lib | `/llms-full.txt` | why |
| --- | --- | --- |
| react-postprocessing | 200, 74 kB | already on `build.yml@v3`; the generator has emitted the dump since v3.2.0, nobody flipped the flag |
| a11y | 200 | pmndrs/react-three-a11y#55 just moved it to `@v4`, deployed green |

The other nine are genuinely off: react-spring, jotai and valtio are documented outside pmndrs, and uikit, xr, prai, viverse, leva are still building with `@v2` (PRs open, plus pmndrs/xr#503, which has to convert off the docker image rather than bump a ref).

Both filtering tests move with the flags, so the exclusion list keeps stating exactly what 404s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0189fTPDjQHrqHxdaMkKCcEC